### PR TITLE
Stock routes for one month and one year prices

### DIFF
--- a/amplify/backend/function/expressServer/src/controllers/stockController.js
+++ b/amplify/backend/function/expressServer/src/controllers/stockController.js
@@ -1,4 +1,6 @@
+const { mockComponent } = require('react-dom/test-utils');
 const Stock = require('../models/stock.model');
+var moment = require('moment')
 
 // @desc get individual stock price
 // @route GET /api/stock/price/:name
@@ -15,7 +17,7 @@ const getStockPrice = async (req, res, next) => {
       return next(new Error('Stock not found'));
     }
 
-    res.json(stock[0].currentprice);
+    res.json(stock[0].prices);
   } catch (err) {
     console.error(err.message);
     res.errormessage = 'Server error';
@@ -109,10 +111,136 @@ const getStockBySymbol = async (req, res, next) => {
   }
 };
 
+// @route   GET api/oneMonthStockData/:symbol
+// @desc    Get stock information for the entire
+// @access  Private - add auth middleware to make it private
+const getOneMonthStockData = async (req, res, next) => {
+  try {
+    const stock = await Stock.find({ symbol: req.params.symbol });
+    const monthly_prices = stock[0].prices
+    if (!stock.length) {
+      // No stock found
+      res.status(404);
+      res.errormessage = 'Stock not found';
+      return next(new Error('Stock not found'));
+    }
+    // Use moment - npm i 
+    const end_Date = moment( moment().subtract(1, 'month') ).format("YYYY-MM-DD")
+
+    // code taken from Borislav Hadzhiev
+    // https://bobbyhadz.com/blog/javascript-get-all-dates-between-two-dates#:~:text=To%20get%20all%20of%20the%20dates%20between%202%20dates%3A&text=Copied!,(date))%3B%20date. 
+    function getDatesInRange(startDate, endDate) {
+      // the below function will create an array of dates from today back one month
+      const date = new Date(startDate.getTime());
+    
+      const dates = [];
+    
+      while (date <= endDate) {
+        new_Date = new Date(date)
+        // the three lines below will put the dates in the format needed to extract the data
+        var year = new_Date.toLocaleString("default", { year: "numeric" });
+        var month = new_Date.toLocaleString("default", { month: "2-digit" });
+        var day = new_Date.toLocaleString("default", { day: "2-digit" });
+        // the date will be added to the array using .push()
+        dates.push(year + "-" + month + "-" + day);
+        date.setDate(date.getDate() + 1);
+      }
+      return dates;
+    }
+    // Date() gives us the current date, Date(end_Date) interprets the 
+    // input date and creates a date that can be used in the function
+    const d1 = new Date(end_Date);
+    const d2 = new Date();
+    
+    // run the function to get the range of dates
+    date_range = getDatesInRange(d1, d2);
+
+    // create an object for the prices (similar to python dictionary)
+    const prices_month = {}
+
+    // loop through the date range list and extract the data
+    for (var i = 0; i < date_range.length; i++) { 
+      // the format of the data keys is "YYYY-MM-DDT20:00:00"
+      if(typeof(monthly_prices[date_range[i]+"T20:00:00"]) != 'undefined'){
+        prices_month[date_range[i]]= monthly_prices[date_range[i]+"T20:00:00"]["4. close"] }}
+    res.json(prices_month);
+  } catch (err) {
+    console.error(err.message);
+    res.errormessage = 'Server error';
+    return next(err);
+  }
+};
+
+
+// @route   GET api/oneYearStockData/:symbol
+// @desc    Get one year stock prices for a specific stock
+// @access  Private - add auth middleware to make it private
+const getOneYearStockData = async (req, res, next) => {
+  try {
+    const stock = await Stock.find({ symbol: req.params.symbol });
+    const yearly_prices = stock[0].prices
+    if (!stock.length) {
+      // No stock found
+      res.status(404);
+      res.errormessage = 'Stock not found';
+      return next(new Error('Stock not found'));
+    }
+
+    // Use moment - npm i
+    const end_Date = moment( moment().subtract(1, 'year') ).format("YYYY-MM-DD")
+
+    // code taken from Borislav Hadzhiev
+    // https://bobbyhadz.com/blog/javascript-get-all-dates-between-two-dates#:~:text=To%20get%20all%20of%20the%20dates%20between%202%20dates%3A&text=Copied!,(date))%3B%20date. 
+    function getDatesInRange(startDate, endDate) {
+      // the below function will create an array of dates from today back one month
+      const date = new Date(startDate.getTime());
+    
+      const dates = [];
+      
+      while (date <= endDate) {
+        new_Date = new Date(date)
+        // the three lines below will put the dates in the format needed to extract the data
+        var year = new_Date.toLocaleString("default", { year: "numeric" });
+        var month = new_Date.toLocaleString("default", { month: "2-digit" });
+        var day = new_Date.toLocaleString("default", { day: "2-digit" });
+        // the date will be added to the array using .push()
+        dates.push(year + "-" + month + "-" + day);
+        date.setDate(date.getDate() + 1);
+      }
+    
+      return dates;
+    }
+    
+    // Date() gives us the current date, Date(end_Date) interprets the 
+    // input date and creates a date that can be used in the function
+    const d1 = new Date(end_Date);
+    const d2 = new Date();
+    
+    // run the function to get the range of dates
+    date_range = getDatesInRange(d1, d2);
+
+    // create an object for the prices (similar to python dictionary)
+    const prices_year = {}
+
+    // loop through the date range list and extract the data
+    for (var i = 0; i < date_range.length; i++) { 
+      // the format of the data keys is "YYYY-MM-DDT20:00:00"
+      if(typeof(yearly_prices[date_range[i]+"T20:00:00"]) != 'undefined'){
+        prices_year[date_range[i]]= yearly_prices[date_range[i]+"T20:00:00"]["4. close"] }}
+    res.json(prices_year);
+  } catch (err) {
+    console.error(err.message);
+    res.errormessage = 'Server error';
+    return next(err);
+  }
+};
+
 module.exports = {
   getStockPrice,
   updateStock,
   addStock,
   getAllStocks,
   getStockBySymbol,
+  getOneMonthStockData,
+  getOneYearStockData,
 };

--- a/amplify/backend/function/expressServer/src/controllers/stockController.js
+++ b/amplify/backend/function/expressServer/src/controllers/stockController.js
@@ -1,4 +1,3 @@
-const { mockComponent } = require('react-dom/test-utils');
 const Stock = require('../models/stock.model');
 var moment = require('moment')
 

--- a/amplify/backend/function/expressServer/src/models/stock.model.js
+++ b/amplify/backend/function/expressServer/src/models/stock.model.js
@@ -8,7 +8,7 @@ const stockSchema = new mongoose.Schema(
     longname: { type: String, trim: true },
     sector: { type: String, trim: true },
     industry: { type: String, trim: true },
-    currentprice: { type: String, trim: true },
+    prices: { type: Object, trim: true },
     marketcap: { type: String, trim: true },
     ebitda: { type: String, trim: true },
     revenuegrowth: { type: String, trim: true },

--- a/amplify/backend/function/expressServer/src/routes/stockRoutes.js
+++ b/amplify/backend/function/expressServer/src/routes/stockRoutes.js
@@ -1,6 +1,6 @@
 const express = require("express")
 const router = express.Router()
-const { getStockPrice, updateStock, addStock, getAllStocks, getStockBySymbol } = require('../controllers/stockController');
+const { getStockPrice, updateStock, addStock, getAllStocks, getStockBySymbol, getOneMonthStockData, getOneYearStockData } = require('../controllers/stockController');
 const { errorHandler } = require("../middleware/errorMiddleware");
 
 // maybe change name to ticker symbol instead
@@ -15,6 +15,9 @@ router.post('/addStock/', addStock)
 router.get('/', getAllStocks)
 // search stock by ticker symbol
 router.get('/:symbol', getStockBySymbol)
-
+// get stock data for one month before today
+router.get('/OneMonthStockData/:symbol', getOneMonthStockData)
+// get stock data for one year before today
+router.get('/OneYearStockData/:symbol', getOneYearStockData)
 
 module.exports = router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15802,6 +15802,11 @@
         "minimist": "^1.2.6"
       }
     },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+    },
     "mongodb": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.9.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "aws-amplify": "^4.3.35",
     "bootstrap": "^5.2.2",
     "config": "^3.3.8",
+    "moment": "^2.29.4",
     "mongoose": "^6.6.4",
     "react": "^18.2.0",
     "react-bootstrap": "^2.5.0",


### PR DESCRIPTION
Here I have added one month and one year stock routes which return the information to the front end in the form:
{
    "2022-09-13": "153.8400",
    "2022-09-14": "155.3100",
    "2022-09-15": "152.3700",
    "2022-09-16": "150.7000",
    "2022-09-19": "154.4800",
    "2022-09-20": "156.9000",
    "2022-09-21": "153.7200",
    "2022-09-22": "152.7400",
    "2022-09-23": "150.4300",
    "2022-09-26": "150.7700",
    "2022-09-27": "151.7600",
    "2022-09-28": "149.8400",
    "2022-09-29": "142.4800",
    "2022-09-30": "138.2000",
    "2022-10-03": "142.4500",
    "2022-10-04": "146.1000",
    "2022-10-05": "146.4000",
    "2022-10-06": "145.4300",
    "2022-10-07": "140.0900",
    "2022-10-10": "140.4200",
    "2022-10-11": "138.9800"
}

Make sure to run this on your own system before approving this (using git fetch and then git checkout -b whateveryouwanttocallit origin/313-Update-Routes-Historical-Data

Run npm i, as I installed 'moment' which is used.

I've added loads of comments to explain how it works.

