### PR TITLE
Reuters article description and 13 new RSS sources

### DIFF
--- a/amplify/backend/function/newsArticleScrapingAndSentimentAnalysis/Pipfile
+++ b/amplify/backend/function/newsArticleScrapingAndSentimentAnalysis/Pipfile
@@ -10,6 +10,7 @@ src = {editable = true, path = "./src"}
 feedparser = "*"
 boto3 = "*"
 pymongo = "*"
+bs4 = "*"
 
 [requires]
 python_version = "3.9"

--- a/amplify/backend/function/newsArticleScrapingAndSentimentAnalysis/Pipfile.lock
+++ b/amplify/backend/function/newsArticleScrapingAndSentimentAnalysis/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dbe113d22b4d8e6d52259aeb1f51630bd3a740061748d3e0604f070ca2597d55"
+            "sha256": "99190f9804fd8ec67fe2f60c4491b7dc89f9618abb7b5fec1814cc76733092a9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,21 +16,36 @@
         ]
     },
     "default": {
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30",
+                "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.11.1"
+        },
         "boto3": {
             "hashes": [
-                "sha256:346f8f0d101a4261dac146a959df18d024feda6431e1d9d84f94efd24d086cae",
-                "sha256:d0d8ffcdc10821c4562bc7f935cdd840033bbc342ac0e14b6bdd348b3adf4c04"
+                "sha256:3225366014949039e6687387242e73f237f0fee0a9b7c20461894f1ee40686b8",
+                "sha256:b295640bc1be637f8f7c8c8fca70781048d6397196109e59f20541824fab4b67"
             ],
             "index": "pypi",
-            "version": "==1.24.89"
+            "version": "==1.24.91"
         },
         "botocore": {
             "hashes": [
-                "sha256:238f1dfdb8d8d017c2aea082609a3764f3161d32745900f41bcdcf290d95a048",
-                "sha256:621f5413be8f97712b7e36c1b075a8791d1d1b9971a7ee060cdcdf5e2debf6c1"
+                "sha256:1d6e97bd8653f732c7078b34aa2bb438e750898957e5a0a74b6c72918bc1d0f7",
+                "sha256:c8fac203a391cc2e4b682877bfce70e723e33c529b35b399a1d574605fbeb1af"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.27.89"
+            "version": "==1.27.91"
+        },
+        "bs4": {
+            "hashes": [
+                "sha256:36ecea1fd7cc5c0c6e4a1ff075df26d50da647b75376626cc186e2212886dd3a"
+            ],
+            "index": "pypi",
+            "version": "==0.0.1"
         },
         "feedparser": {
             "hashes": [
@@ -150,6 +165,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "soupsieve": {
+            "hashes": [
+                "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759",
+                "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.3.2.post1"
         },
         "src": {
             "editable": true,

--- a/amplify/backend/function/newsArticleScrapingAndSentimentAnalysis/src/index.py
+++ b/amplify/backend/function/newsArticleScrapingAndSentimentAnalysis/src/index.py
@@ -14,7 +14,6 @@ from pymongo.errors import DuplicateKeyError
 from datetime import datetime
 from datetime import timedelta
 from time import mktime
-from pprint import pprint
 from bs4 import  BeautifulSoup
 
 ### Directory Setup ###

--- a/amplify/backend/function/newsArticleScrapingAndSentimentAnalysis/src/lib/RSSSources.json
+++ b/amplify/backend/function/newsArticleScrapingAndSentimentAnalysis/src/lib/RSSSources.json
@@ -55,6 +55,13 @@
    "ImageTag": "media_content",
    "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/new_york_times_logo.jpg"
  },
+  {
+   "Source": "Reuters",
+   "Topic": "Business",
+   "URL": "https://www.reutersagency.com/feed/?best-topics=business-finance&post_type=best",
+   "ImageTag": "",
+   "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/reuters_logo.png"
+  },
  {
    "Source": "Reuters",
    "Topic": "Deals",
@@ -64,8 +71,15 @@
  },
  {
    "Source": "Reuters",
-   "Topic": "Business",
-   "URL": "https://www.reutersagency.com/feed/?best-topics=business-finance&post_type=best",
+   "Topic": "Politics",
+   "URL": "https://www.reutersagency.com/feed/?best-topics=political-general&post_type=best",
+   "ImageTag": "",
+   "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/reuters_logo.png"
+ },
+ {
+   "Source": "Reuters",
+   "Topic": "Energy Environment",
+   "URL": "https://www.reutersagency.com/feed/?best-topics=environment&post_type=best",
    "ImageTag": "",
    "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/reuters_logo.png"
  },
@@ -73,6 +87,34 @@
    "Source": "Reuters",
    "Topic": "Technology",
    "URL": "https://www.reutersagency.com/feed/?best-topics=tech&post_type=best",
+   "ImageTag": "",
+   "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/reuters_logo.png"
+ },
+ {
+   "Source": "Reuters",
+   "Topic": "Health",
+   "URL": "https://www.reutersagency.com/feed/?best-topics=health&post_type=best",
+   "ImageTag": "",
+   "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/reuters_logo.png"
+ },
+ {
+   "Source": "Reuters",
+   "Topic": "Sports",
+   "URL": "https://www.reutersagency.com/feed/?best-topics=sports&post_type=best",
+   "ImageTag": "",
+   "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/reuters_logo.png"
+ },
+ {
+   "Source": "Reuters",
+   "Topic": "Media",
+   "URL": "https://www.reutersagency.com/feed/?best-topics=lifestyle-entertainment&post_type=best",
+   "ImageTag": "",
+   "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/reuters_logo.png"
+ },
+ {
+   "Source": "Reuters",
+   "Topic": "Human Interest",
+   "URL": "https://www.reutersagency.com/feed/?best-topics=human-interest&post_type=best",
    "ImageTag": "",
    "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/reuters_logo.png"
  },
@@ -122,6 +164,55 @@
   "Source":"CNBC",
   "Topic":"World News",
   "URL":"https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=100727362",
+  "ImageTag": "",
+  "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/cnbc_logo.png"
+ },
+ {
+  "Source":"CNBC",
+  "Topic":"Energy Environment",
+  "URL":"https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=19836768",
+  "ImageTag": "",
+  "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/cnbc_logo.png"
+ },
+ {
+  "Source":"CNBC",
+  "Topic":"Economy",
+  "URL":"https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=20910258",
+  "ImageTag": "",
+  "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/cnbc_logo.png"
+ },
+ {
+  "Source":"CNBC",
+  "Topic":"Health",
+  "URL":"https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=10000108",
+  "ImageTag": "",
+  "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/cnbc_logo.png"
+ },
+ {
+  "Source":"CNBC",
+  "Topic":"Retail",
+  "URL":"https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=10000116",
+  "ImageTag": "",
+  "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/cnbc_logo.png"
+ },
+ {
+  "Source":"CNBC",
+  "Topic":"Auto",
+  "URL":"https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=10000101",
+  "ImageTag": "",
+  "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/cnbc_logo.png"
+ },
+ {
+  "Source":"CNBC",
+  "Topic":"Media",
+  "URL":"https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=10000110",
+  "ImageTag": "",
+  "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/cnbc_logo.png"
+ },
+ {
+  "Source":"CNBC",
+  "Topic":"Politics",
+  "URL":"https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=10000113",
   "ImageTag": "",
   "DefaultImage": "https://stockappnewslogobucket.s3.eu-west-1.amazonaws.com/cnbc_logo.png"
  },

--- a/amplify/backend/function/newsArticleScrapingAndSentimentAnalysis/src/src.egg-info/SOURCES.txt
+++ b/amplify/backend/function/newsArticleScrapingAndSentimentAnalysis/src/src.egg-info/SOURCES.txt
@@ -1,4 +1,5 @@
 index.py
+pyproject.toml
 setup.py
 src.egg-info/PKG-INFO
 src.egg-info/SOURCES.txt


### PR DESCRIPTION
Noticed a problem with the Reuters articles where the description was being stored using the HTML tags in the database. They used two descriptions in 2 <p> tags, the first was always half a sentence, the function getReutersDescription now parses the second <p> and get a proper article description. Added 13 new RSS feeds to parse, the total number of RSS feeds parsed for articles is now 32.

