### PR TITLE
Infobutton components created #350

### DIFF
--- a/src/components/stockVisualisationComponents/ChartCard/ChartCard.js
+++ b/src/components/stockVisualisationComponents/ChartCard/ChartCard.js
@@ -3,9 +3,6 @@ import { useState, useEffect } from "react";
 import BarChartViz from "../ChartTypes/BarChartViz/BarChartViz";
 import PieChartViz from "../ChartTypes/PieChartViz/PieChartViz";
 import RadarChartViz from "../ChartTypes/RadarChartViz/RadarChartViz";
-import { Info } from "react-feather"
-//TODO
-// Move dropdown to right hand side without losing functionality of button
 
 const ChartCard = ({ title, data }) => {
 
@@ -52,7 +49,7 @@ const ChartCard = ({ title, data }) => {
         <>
             <Card className="infoCardStyle">
                 <Container>
-                    <h2>{title}  <Info size={20}/></h2>
+                    <h2>{title}  </h2>
                         <Dropdown>
                             <Dropdown.Toggle variant="success" id="dropdown-basic" size="sm">
                                 Graph Type

--- a/src/components/stockVisualisationComponents/ChartTypes/PriceChart/PriceChart.js
+++ b/src/components/stockVisualisationComponents/ChartTypes/PriceChart/PriceChart.js
@@ -9,13 +9,28 @@ import {
 } from "recharts";
 
 import { Container, Button, Card, Row, Col } from "react-bootstrap";
-import { useState, useEffect } from "react";
+import { useState, useEffect, PureComponent } from "react";
 import LoadingSpinner from "../../../widgets/LoadingSpinner/LoadingSpinner";
 import MessageAlert from "../../../widgets/MessageAlert/MessageAlert";
 
 /// API ///
 import { APIName } from "../../../../constants/APIConstants";
 import { API } from "aws-amplify";
+
+
+class CustomizedAxisTick extends PureComponent {
+    render() {
+      const { x, y, stroke, payload } = this.props;
+  
+      return (
+        <g transform={`translate(${x},${y})`}>
+          <text x={0} y={0} dy={16} textAnchor="end" fill="#666" transform="rotate(-35)">
+            {payload.value}
+          </text>
+        </g>
+      );
+    }
+  }
 
 function StockPriceChart({ symbol }) {
 
@@ -102,8 +117,8 @@ function StockPriceChart({ symbol }) {
                                     <CartesianGrid strokeDasharray="3 3" vertical={false}></CartesianGrid>
                                     <XAxis dataKey="date"
                                         stroke="black"
-                                        // tick={<CustomizedAxisTick />}
-                                        tick={false}
+                                         tick={<CustomizedAxisTick />}
+                            
                                     >
                                     </XAxis>
                                     <YAxis />

--- a/src/components/stockVisualisationComponents/ChartTypes/PriceChart/PriceChart.js
+++ b/src/components/stockVisualisationComponents/ChartTypes/PriceChart/PriceChart.js
@@ -122,10 +122,6 @@ function StockPriceChart({ symbol }) {
                                     >
                                     </XAxis>
                                     <YAxis />
-                                    {/* dataKey="price"
-                                    stroke="false">
-                                    <Label value="Price $" position="left" angle="-90"></Label>
-                                </YAxis> */}
                                     <Area type="monotone" dataKey="price" stroke="#00C49F" fillOpacity={1} fill="url(#colorPrice)" />
                                 </AreaChart>
                             </ResponsiveContainer>

--- a/src/components/stockVisualisationComponents/ChartTypes/PriceChart/PriceChart.js
+++ b/src/components/stockVisualisationComponents/ChartTypes/PriceChart/PriceChart.js
@@ -20,7 +20,7 @@ import { API } from "aws-amplify";
 
 class CustomizedAxisTick extends PureComponent {
     render() {
-      const { x, y, stroke, payload } = this.props;
+      const { x, y, payload } = this.props;
   
       return (
         <g transform={`translate(${x},${y})`}>

--- a/src/components/stockVisualisationComponents/ChartTypes/PriceChart/PriceChart.js
+++ b/src/components/stockVisualisationComponents/ChartTypes/PriceChart/PriceChart.js
@@ -52,26 +52,12 @@ function StockPriceChart({ symbol }) {
         getOneMonthPrices();
     }, [])
 
-    const month = [
-        { name: 'month', price: 100 },
-        { name: 'month', price: 500 },
-        { name: 'month', price: 60 },
-        { name: 'month', price: 700 },
-        { name: 'month', price: 800 }]
-
     const day = [
         { name: '2022-01-10', price: 400 },
         { name: '2022-01-11', price: 700 },
         { name: '2022-01-12', price: 60 },
         { name: '2022-01-13', price: 700 },
         { name: '2022-01-1', price: 500 }]
-
-    const year = [
-        { name: '2017', price: 400 },
-        { name: '2018', price: 10 },
-        { name: '2019', price: 60 },
-        { name: '2020', price: 700 },
-        { name: '2021', price: 100 }]
 
     const DayData = event => {
         // toggle shown data

--- a/src/components/stockVisualisationComponents/ChartTypes/PriceChart/PriceChart.js
+++ b/src/components/stockVisualisationComponents/ChartTypes/PriceChart/PriceChart.js
@@ -9,7 +9,7 @@ import {
 } from "recharts";
 
 import { Container, Button, Card, Row, Col } from "react-bootstrap";
-import { useState, useEffect, PureComponent } from "react";
+import { useState, useEffect } from "react";
 import LoadingSpinner from "../../../widgets/LoadingSpinner/LoadingSpinner";
 import MessageAlert from "../../../widgets/MessageAlert/MessageAlert";
 
@@ -17,20 +17,6 @@ import MessageAlert from "../../../widgets/MessageAlert/MessageAlert";
 import { APIName } from "../../../../constants/APIConstants";
 import { API } from "aws-amplify";
 
-
-class CustomizedAxisTick extends PureComponent {
-    render() {
-      const { x, y, payload } = this.props;
-  
-      return (
-        <g transform={`translate(${x},${y})`}>
-          <text x={0} y={0} dy={16} textAnchor="end" fill="#666" transform="rotate(-35)">
-            {payload.value}
-          </text>
-        </g>
-      );
-    }
-  }
 
 function StockPriceChart({ symbol }) {
 
@@ -116,9 +102,7 @@ function StockPriceChart({ symbol }) {
                                     />
                                     <CartesianGrid strokeDasharray="3 3" vertical={false}></CartesianGrid>
                                     <XAxis dataKey="date"
-                                        stroke="black"
-                                         tick={<CustomizedAxisTick />}
-                            
+                                        stroke="black"                            
                                     >
                                     </XAxis>
                                     <YAxis />

--- a/src/components/stockVisualisationComponents/PlainCard/PlainCard.js
+++ b/src/components/stockVisualisationComponents/PlainCard/PlainCard.js
@@ -1,6 +1,5 @@
 import { Container, Card } from "react-bootstrap";
 import InfoButtonModal from "../../widgets/InfoButtonModal/InfoButtonModal";
-// import InfoButtonHover from "../../widgets/InfoButtonHover/InfoButtonHover";
 
 const PlainCard = ({ longname, symbol, logo, info }) => {
 
@@ -16,7 +15,6 @@ const PlainCard = ({ longname, symbol, logo, info }) => {
                                 <InfoButtonModal 
                                 title="Company Information"
                                 info={info} />
-                                {/* <InfoButtonHover setPlacement="left"/> */}
                                 </h2>
                                 </dt>
                

--- a/src/components/stockVisualisationComponents/PlainCard/PlainCard.js
+++ b/src/components/stockVisualisationComponents/PlainCard/PlainCard.js
@@ -1,9 +1,8 @@
 import { Container, Card } from "react-bootstrap";
 import InfoButtonModal from "../../widgets/InfoButtonModal/InfoButtonModal";
-import InfoButtonHover from "../../widgets/InfoButtonHover/InfoButtonHover";
+// import InfoButtonHover from "../../widgets/InfoButtonHover/InfoButtonHover";
 
 const PlainCard = ({ longname, symbol, logo, info }) => {
-
 
     return (
         <>

--- a/src/components/stockVisualisationComponents/PlainCard/PlainCard.js
+++ b/src/components/stockVisualisationComponents/PlainCard/PlainCard.js
@@ -1,13 +1,8 @@
-import { Container, Card, Modal, Button } from "react-bootstrap";
-import { Info } from "react-feather"
-import { useState } from "react";
+import { Container, Card } from "react-bootstrap";
+import InfoButton from "../../widgets/InfoButton/InfoButton";
 
 const PlainCard = ({ longname, symbol, logo, info }) => {
 
-    const [show, setShow] = useState(false);
-
-    const handleClose = () => setShow(false);
-    const handleShow = () => setShow(true);
 
     return (
         <>
@@ -15,8 +10,18 @@ const PlainCard = ({ longname, symbol, logo, info }) => {
                 <Container>
                     <img src={logo} className="img-fluid" alt="Company Logo" style={{ width: "20%" }} />
                     <div>
-                        <dl style={{marginTop:"10px"}}>
-                            <dt><h2>{longname}  <Info size={20} onClick={handleShow} /></h2></dt>
+                        <dl style={{ marginTop: "10px" }}>
+                   
+                                <dt><h2>{longname}  
+                                <InfoButton 
+                                title="Company Information"
+                                info={info}
+                                
+                                />
+
+                                </h2>
+                                </dt>
+               
                             <dt><h5 style={{ fontFamily: 'Courier New' }}>{symbol}</h5></dt>
                             <dt>$200</dt>
                             <dt>+$50 (25%)</dt>
@@ -25,7 +30,7 @@ const PlainCard = ({ longname, symbol, logo, info }) => {
 
                 </Container>
             </Card>
-            <Modal show={show} onHide={handleClose}>
+            {/* <Modal show={show} onHide={handleClose}>
                 <Modal.Header closeButton>
                     <Modal.Title>Company Information</Modal.Title>
                 </Modal.Header>
@@ -35,7 +40,7 @@ const PlainCard = ({ longname, symbol, logo, info }) => {
                         Close
                     </Button>
                 </Modal.Footer>
-            </Modal>
+            </Modal> */}
         </>
     )
 }

--- a/src/components/stockVisualisationComponents/PlainCard/PlainCard.js
+++ b/src/components/stockVisualisationComponents/PlainCard/PlainCard.js
@@ -26,17 +26,6 @@ const PlainCard = ({ longname, symbol, logo, info }) => {
 
                 </Container>
             </Card>
-            {/* <Modal show={show} onHide={handleClose}>
-                <Modal.Header closeButton>
-                    <Modal.Title>Company Information</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>{info}</Modal.Body>
-                <Modal.Footer>
-                    <Button variant="secondary" onClick={handleClose}>
-                        Close
-                    </Button>
-                </Modal.Footer>
-            </Modal> */}
         </>
     )
 }

--- a/src/components/stockVisualisationComponents/PlainCard/PlainCard.js
+++ b/src/components/stockVisualisationComponents/PlainCard/PlainCard.js
@@ -1,5 +1,6 @@
 import { Container, Card } from "react-bootstrap";
-import InfoButton from "../../widgets/InfoButton/InfoButton";
+import InfoButtonModal from "../../widgets/InfoButtonModal/InfoButtonModal";
+import InfoButtonHover from "../../widgets/InfoButtonHover/InfoButtonHover";
 
 const PlainCard = ({ longname, symbol, logo, info }) => {
 
@@ -12,13 +13,15 @@ const PlainCard = ({ longname, symbol, logo, info }) => {
                     <div>
                         <dl style={{ marginTop: "10px" }}>
                    
-                                <dt><h2>{longname}  
-                                <InfoButton 
+                                <dt><h2>{longname} 
+                                <br></br> 
+                                {/* <InfoButtonModal 
                                 title="Company Information"
                                 info={info}
                                 
-                                />
+                                /> */}
 
+                                <InfoButtonHover setPlacement="left"/>
                                 </h2>
                                 </dt>
                

--- a/src/components/stockVisualisationComponents/PlainCard/PlainCard.js
+++ b/src/components/stockVisualisationComponents/PlainCard/PlainCard.js
@@ -14,14 +14,10 @@ const PlainCard = ({ longname, symbol, logo, info }) => {
                         <dl style={{ marginTop: "10px" }}>
                    
                                 <dt><h2>{longname} 
-                                <br></br> 
-                                {/* <InfoButtonModal 
+                                <InfoButtonModal 
                                 title="Company Information"
-                                info={info}
-                                
-                                /> */}
-
-                                <InfoButtonHover setPlacement="left"/>
+                                info={info} />
+                                {/* <InfoButtonHover setPlacement="left"/> */}
                                 </h2>
                                 </dt>
                

--- a/src/components/widgets/InfoButton/InfoButton.js
+++ b/src/components/widgets/InfoButton/InfoButton.js
@@ -1,0 +1,35 @@
+import { Info } from "react-feather";
+import { useState } from "react";
+import { Modal, Button } from "react-bootstrap";
+
+const InfoButton = ({  title, info }) => {
+
+    const [show, setShow] = useState(false);
+
+    const handleClose = () => setShow(false);
+    const handleShow = () => setShow(true);
+
+    return (
+        <>
+            <sup>
+                <Info size={20} color="#595959" onClick={handleShow}
+                ></Info>
+            </sup>
+            <Modal show={show} onHide={handleClose}>
+                <Modal.Header closeButton>
+                    <Modal.Title>{title}</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>{info}</Modal.Body>
+                <Modal.Footer>
+                    <Button variant="secondary" onClick={handleClose}>
+                        Close
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+            {/* </div> */}
+        </>
+
+    )
+}
+
+export default InfoButton;

--- a/src/components/widgets/InfoButtonHover/InfoButtonHover.js
+++ b/src/components/widgets/InfoButtonHover/InfoButtonHover.js
@@ -2,7 +2,7 @@ import { Info } from "react-feather";
 import { useState, useRef } from "react";
 import { Overlay, Tooltip } from 'react-bootstrap';
 
-// Set placement using left, right, bottom or top
+// Set placement using setPlacement prop and left, right, bottom or top
 
 const InfoButtonHover = ({ info, setPlacement }) => {
 
@@ -12,14 +12,12 @@ const InfoButtonHover = ({ info, setPlacement }) => {
     return (
         <>
             <sup>
-                <Info size={20} className="infobuttonStyle" ref={target} onClick={() => setShow(!show)}></Info>
+                <Info className="infobuttonStyle" ref={target} onClick={() => setShow(!show)}></Info>
             </sup>
 
             <Overlay target={target.current} show={show} placement={setPlacement}>
                 {(props) => (
-                    <Tooltip id="overlay-example"
-                        {...props}
-                    >
+                    <Tooltip {...props}>
                         {info}
                     </Tooltip>
                 )}

--- a/src/components/widgets/InfoButtonHover/InfoButtonHover.js
+++ b/src/components/widgets/InfoButtonHover/InfoButtonHover.js
@@ -2,26 +2,28 @@ import { Info } from "react-feather";
 import { useState, useRef } from "react";
 import { Overlay, Tooltip } from 'react-bootstrap';
 
+// Set placement using left, right, bottom or top
+
 const InfoButtonHover = ({ info, setPlacement }) => {
 
     const [show, setShow] = useState(false);
     const target = useRef(null);
-    
+
     return (
         <>
             <sup>
-                <Info size={20} color="#595959" ref={target} onClick={() => setShow(!show)}></Info>
+                <Info size={20} className="infobuttonStyle" ref={target} onClick={() => setShow(!show)}></Info>
             </sup>
 
-      <Overlay target={target.current} show={show} placement={setPlacement}>
-        {(props) => (
-          <Tooltip id="overlay-example"
-           {...props}
-           >
-            {info}
-          </Tooltip>
-        )}
-      </Overlay>
+            <Overlay target={target.current} show={show} placement={setPlacement}>
+                {(props) => (
+                    <Tooltip id="overlay-example"
+                        {...props}
+                    >
+                        {info}
+                    </Tooltip>
+                )}
+            </Overlay>
         </>
 
     )

--- a/src/components/widgets/InfoButtonHover/InfoButtonHover.js
+++ b/src/components/widgets/InfoButtonHover/InfoButtonHover.js
@@ -1,0 +1,32 @@
+import { Info } from "react-feather";
+import { useState, useRef } from "react";
+import { Overlay, Tooltip, Button } from 'react-bootstrap';
+
+const InfoButtonHover = ({ info, setPlacement }) => {
+
+    const [show, setShow] = useState(false);
+    const target = useRef(null);
+
+    const myInfo = "Some string"
+
+    return (
+        <>
+            <sup>
+                <Info size={20} color="#595959" ref={target} onClick={() => setShow(!show)}></Info>
+            </sup>
+
+      <Overlay target={target.current} show={show} placement={setPlacement}>
+        {(props) => (
+          <Tooltip id="overlay-example"
+           {...props}
+           >
+            {myInfo}
+          </Tooltip>
+        )}
+      </Overlay>
+        </>
+
+    )
+}
+
+export default InfoButtonHover;

--- a/src/components/widgets/InfoButtonHover/InfoButtonHover.js
+++ b/src/components/widgets/InfoButtonHover/InfoButtonHover.js
@@ -1,14 +1,12 @@
 import { Info } from "react-feather";
 import { useState, useRef } from "react";
-import { Overlay, Tooltip, Button } from 'react-bootstrap';
+import { Overlay, Tooltip } from 'react-bootstrap';
 
 const InfoButtonHover = ({ info, setPlacement }) => {
 
     const [show, setShow] = useState(false);
     const target = useRef(null);
-
-    const myInfo = "Some string"
-
+    
     return (
         <>
             <sup>
@@ -20,7 +18,7 @@ const InfoButtonHover = ({ info, setPlacement }) => {
           <Tooltip id="overlay-example"
            {...props}
            >
-            {myInfo}
+            {info}
           </Tooltip>
         )}
       </Overlay>

--- a/src/components/widgets/InfoButtonModal/InfoButtonModal.js
+++ b/src/components/widgets/InfoButtonModal/InfoButtonModal.js
@@ -2,7 +2,7 @@ import { Info } from "react-feather";
 import { useState } from "react";
 import { Modal, Button } from "react-bootstrap";
 
-const InfoButton = ({  title, info }) => {
+const InfoButtonModal = ({  title, info }) => {
 
     const [show, setShow] = useState(false);
 
@@ -12,8 +12,7 @@ const InfoButton = ({  title, info }) => {
     return (
         <>
             <sup>
-                <Info size={20} color="#595959" onClick={handleShow}
-                ></Info>
+                <Info size={20} color="#595959" onClick={handleShow}></Info>
             </sup>
             <Modal show={show} onHide={handleClose}>
                 <Modal.Header closeButton>
@@ -26,10 +25,9 @@ const InfoButton = ({  title, info }) => {
                     </Button>
                 </Modal.Footer>
             </Modal>
-            {/* </div> */}
         </>
 
     )
 }
 
-export default InfoButton;
+export default InfoButtonModal;

--- a/src/components/widgets/InfoButtonModal/InfoButtonModal.js
+++ b/src/components/widgets/InfoButtonModal/InfoButtonModal.js
@@ -12,7 +12,7 @@ const InfoButtonModal = ({ title, info }) => {
     return (
         <>
             <sup>
-                <Info size={20} className="infobuttonStyle" onClick={handleShow}></Info>
+                <Info className="infobuttonStyle" onClick={handleShow}></Info>
             </sup>
             <Modal show={show} onHide={handleClose}>
                 <Modal.Header closeButton>

--- a/src/components/widgets/InfoButtonModal/InfoButtonModal.js
+++ b/src/components/widgets/InfoButtonModal/InfoButtonModal.js
@@ -2,7 +2,7 @@ import { Info } from "react-feather";
 import { useState } from "react";
 import { Modal, Button } from "react-bootstrap";
 
-const InfoButtonModal = ({  title, info }) => {
+const InfoButtonModal = ({ title, info }) => {
 
     const [show, setShow] = useState(false);
 
@@ -12,7 +12,7 @@ const InfoButtonModal = ({  title, info }) => {
     return (
         <>
             <sup>
-                <Info size={20} color="#595959" onClick={handleShow}></Info>
+                <Info size={20} className="infobuttonStyle" onClick={handleShow}></Info>
             </sup>
             <Modal show={show} onHide={handleClose}>
                 <Modal.Header closeButton>

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -8,13 +8,18 @@
 /* Sentiment */
 @import "./sentimentComponents/sentimentBadge.scss";
 
+/* Widgets */
+/* Infobutton */
+
+@import "./widgetsComponents/infoButton.scss";
+
 
 
 $primary: #006195;
 $background: #ffffff;
 $text-colour: #020202;
 $submit: #e16202;
-$info: #595959;
+
 
 body {
     background-color: $background;
@@ -63,6 +68,3 @@ h1, .h1 {
 }
 
 
-.infobuttonStyle{
-    color: $info;
-}

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -131,3 +131,8 @@ h1, .h1 {
     font-size: 85%;
     background-color:#FFA500 !important;
 }
+
+.infobuttonStyle{
+    font-weight: lighter;
+    font-size: 85%;
+}

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -61,3 +61,8 @@ h1, .h1 {
     padding-bottom:50px;
     display:flex;
 }
+
+
+.infobuttonStyle{
+    color: $info;
+}

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -5,6 +5,7 @@ $primary: #006195;
 $background: #ffffff;
 $text-colour: #020202;
 $submit: #e16202;
+$info: #595959;
 
 body {
     background-color: $background;
@@ -133,6 +134,5 @@ h1, .h1 {
 }
 
 .infobuttonStyle{
-    font-weight: lighter;
-    font-size: 85%;
+    color: $info;
 }

--- a/src/scss/widgetsComponents/infoButton.scss
+++ b/src/scss/widgetsComponents/infoButton.scss
@@ -1,0 +1,8 @@
+$info: #595959;
+
+.infobuttonStyle{
+    color: $info;
+    width: 20px;
+    height: 20px;
+    margin: 5px
+}

--- a/src/scss/widgetsComponents/infoButton.scss
+++ b/src/scss/widgetsComponents/infoButton.scss
@@ -2,7 +2,7 @@ $info: #595959;
 
 .infobuttonStyle{
     color: $info;
-    width: 20px;
-    height: 20px;
-    margin: 5px
+    width: 1.25rem;
+    height: 1.25rem;
+    margin: 0.5em
 }


### PR DESCRIPTION
Created 2x info button components. The first is a standard button with a modal, shown below. The second is one with a hover info component. With the second button ,you can set the placement to have it top, bottom, left or right as a prop.

Also deleted a few comments here and there.

For pushing to the app, I'm using the modal button on the company information section of the stock information page.

![image](https://user-images.githubusercontent.com/78801723/196189000-bb2cd532-71e8-4b2b-8cbf-1c6e045c1281.png)

Modal:
![image](https://user-images.githubusercontent.com/78801723/196189120-73a06c66-a2ac-43bd-bd74-768998709a91.png)

Examples of the hover button in action:
Hover with right prop
![image](https://user-images.githubusercontent.com/78801723/196189478-a1291f35-22a4-4228-86dc-9c27b0b7afde.png)

Hover with bottom prop 
![image](https://user-images.githubusercontent.com/78801723/196189921-849b8f10-691e-47b2-8657-da821097313e.png)
