### PR TITLE
Added password length checker to registration screen with minimum len…

### DIFF
--- a/src/screens/registration/registrationScreen.js
+++ b/src/screens/registration/registrationScreen.js
@@ -35,7 +35,7 @@ function RegistrationPage() {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
-  const [errorMessage, setErrorMessage] = useState(null)
+  const [passwordErrorMessage, setPasswordErrorMessage] = useState(null)
 
   const navigate = useNavigate()
 
@@ -51,8 +51,14 @@ function RegistrationPage() {
     event.preventDefault()
     // Check whether password and confirm password are the same. More messages will need to be added.
     if (password !== confirmPassword) {
-      setErrorMessage('Password and Confirm Password must be the same!')
-    } else {
+      setPasswordErrorMessage('Password and Confirm Password must be the same!')
+    } 
+    // Checks if the password is less than 8 characters. Gives a popup warning if it is.
+    else if (validatePasswordLength(password !== true)) {
+      setPasswordErrorMessage('Password must be at least 8 characters!')
+    } 
+    
+    else {
       // location returns a dictionary of items such as country ID and name, but we only want name here.
       dispatch(
         registerUser(
@@ -67,6 +73,16 @@ function RegistrationPage() {
     }
   }
 
+  // Function that checks if the user entered password is longer than 8 characters
+  function validatePasswordLength(password) {
+    var p = password
+    if (p.length <= 8) {
+      return false
+    } else {
+      return true
+    }
+  }
+
   // Redirect if the user is logged in (stock disovery for now will change to profile later)
   useEffect(() => {
     if (userInfo) {
@@ -77,9 +93,6 @@ function RegistrationPage() {
   return (
     <FormContainer>
       <h1>Register</h1>
-      {errorMessage && (
-        <MessageAlert variant="danger">{errorMessage}</MessageAlert>
-      )}
       {error && <MessageAlert variant="danger">{error}</MessageAlert>}
       {loading && <LoadingSpinner />}
       <Form onSubmit={handleSubmit}>
@@ -145,6 +158,9 @@ function RegistrationPage() {
             required
           />
         </Form.Group>
+        {passwordErrorMessage && (
+          <MessageAlert variant="danger">{passwordErrorMessage}</MessageAlert>
+        )}
         <br></br>
         <Form.Group>
           <Form.Check


### PR DESCRIPTION
…gth enforcement of 8 characters. 

# Running with no errors

![running_no_errors](https://user-images.githubusercontent.com/78538312/196477715-b4c33e50-9937-4ced-b4ca-5796e7f2181e.JPG)

# Changes

- Added password length check with red error popup
![password_length_error_msg](https://user-images.githubusercontent.com/78538312/196478108-2b0d3394-1ec4-482d-9e96-0c096cb81267.JPG)


---
# Future Work

- I tried to add in a password length checker to the password field, most of this work was done however I ran out of time to get it fully implemented and need to move on. I have these changes saved locally and will eventually add this change but for now I need to move onto the stock discovery search feature. 
- When I am doing this I will also update the registration form to use REACT components, as it stands it's quite hard to adjust and update elements because all the fields are hardcoded into the registration page.

It will look something like this:
![image](https://user-images.githubusercontent.com/78538312/196478547-c169be3b-071d-4ea2-8f29-98df194ba940.png)
