### PR TITLE
Stock price data in number format

### DIFF
--- a/amplify/backend/function/stockPriceIntraDay/Pipfile.lock
+++ b/amplify/backend/function/stockPriceIntraDay/Pipfile.lock
@@ -26,19 +26,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:3c6cc4e9e38cf4523267f89eb90c0b6084fa415cb4f44e3bf0cad6199340cc92",
-                "sha256:d28bcb98aee4d333b163c55b98341627d933dbf088832f7fc050893617be7dac"
+                "sha256:05818ed61af104f28f039592c5c54d802a0398b1f158c2d485ec86352b48033f",
+                "sha256:285d29042c1684f8fc68492ddf20180d28b94aac1f19dd7161bcad3067c01314"
             ],
             "index": "pypi",
-            "version": "==1.24.92"
+            "version": "==1.24.95"
         },
         "botocore": {
             "hashes": [
-                "sha256:70cf2cb04968794ed4688cc3b07874f6f4c932e325611be4e693a995fdb481be",
-                "sha256:b49c34b80c782625905be75e669da4b42a99f074e0aa3007e15ccc6955682a07"
+                "sha256:04ff12a8d1d0687a1f1c2dfad5b6fc9f5a81de4b639cf9c9e41fee9449680fd4",
+                "sha256:0b90945aa7080179a0c4941a3809ce4df30792931e16b9b6ef3c739c4f2b7a59"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.27.92"
+            "version": "==1.27.95"
         },
         "bs4": {
             "hashes": [
@@ -185,7 +185,8 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22"
+                "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22",
+                "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"
             ],
             "version": "==2022.5"
         },

--- a/amplify/backend/function/stockPriceIntraDay/Pipfile.lock
+++ b/amplify/backend/function/stockPriceIntraDay/Pipfile.lock
@@ -26,19 +26,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:05818ed61af104f28f039592c5c54d802a0398b1f158c2d485ec86352b48033f",
-                "sha256:285d29042c1684f8fc68492ddf20180d28b94aac1f19dd7161bcad3067c01314"
+                "sha256:6b8899542cff82becceb3498a2240bf77c96def0515b0a31f7f6a9d5b92e7a3d",
+                "sha256:748c055214c629744c34c7f94bfa888733dfac0b92e1daef9c243e1391ea4f53"
             ],
             "index": "pypi",
-            "version": "==1.24.95"
+            "version": "==1.24.96"
         },
         "botocore": {
             "hashes": [
-                "sha256:04ff12a8d1d0687a1f1c2dfad5b6fc9f5a81de4b639cf9c9e41fee9449680fd4",
-                "sha256:0b90945aa7080179a0c4941a3809ce4df30792931e16b9b6ef3c739c4f2b7a59"
+                "sha256:e41a81a18511f2f9181b2a9ab302a55c0effecccbef846c55aad0c47bfdbefb9",
+                "sha256:fc0a13ef6042e890e361cf408759230f8574409bb51f81740d2e5d8ad5d1fbea"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.27.95"
+            "version": "==1.27.96"
         },
         "bs4": {
             "hashes": [

--- a/amplify/backend/function/stockPriceIntraDay/src/index.py
+++ b/amplify/backend/function/stockPriceIntraDay/src/index.py
@@ -89,7 +89,7 @@ def get_current_price():
     for i in range(0, len(data)):
       # add to dictionary in the form Symbol: Price
       # the data is also converted from string to float where possible
-      output[data[i][2]] = {"currentprice": float(data[i][4].replace(',', '')), "absoluteChange": float(data[i][5]), "percentageChange": data[i][6].strip("()")}
+      output[data[i][2]] = {"currentprice": float(data[i][4].replace(',', '')), "absoluteChange": float(data[i][5]), "percentageChange": float(data[i][6].strip("()%"))}
     return output
 
   

--- a/amplify/backend/function/stockPriceIntraDay/src/index.py
+++ b/amplify/backend/function/stockPriceIntraDay/src/index.py
@@ -88,7 +88,8 @@ def get_current_price():
     output = {}
     for i in range(0, len(data)):
       # add to dictionary in the form Symbol: Price
-      output[data[i][2]] = {"currentprice": data[i][4], "absoluteChange": data[i][5], "percentageChange": data[i][6].strip("()")}
+      # the data is also converted from string to float where possible
+      output[data[i][2]] = {"currentprice": float(data[i][4].replace(',', '')), "absoluteChange": float(data[i][5]), "percentageChange": data[i][6].strip("()")}
     return output
 
   


### PR DESCRIPTION
Very small change to the lambda function. Just a matter of processing the data to come in number rather than string. For percentages, Daragh noted it would be easier for him to sort top movers if the data comes as float. 

When used on the front end a '%' will need to be added.

Mock function looks like this (positive and negative number example):
<img width="164" alt="image" src="https://user-images.githubusercontent.com/81182125/197357010-d5f388b7-8bb0-4902-9480-acf8988f5ab8.png">
<img width="160" alt="image" src="https://user-images.githubusercontent.com/81182125/197357081-c8050567-1a23-4190-a5d2-5e3382c5db6d.png">

