### PR TITLE
Stock price data in number format

### DIFF
--- a/amplify/backend/function/stockPriceIntraDay/src/index.py
+++ b/amplify/backend/function/stockPriceIntraDay/src/index.py
@@ -121,6 +121,10 @@ def create_data_request(data_curr_price, time_stamp):
           i_new = "BRK-B"
           data_request.append(UpdateOne({"symbol": i_new}, {'$set': {"daily_change": data_curr_price[i]}}))
           data_request.append(UpdateOne({"symbol": i_new}, {'$set': {name: {"time": time_stamp, "4. close": data_curr_price[i]["currentprice"]}}}))
+      elif i == "BF.B":
+          i_new = "BF-B"
+          data_request.append(UpdateOne({"symbol": i_new}, {'$set': {"daily_change": data_curr_price[i]}}))
+          data_request.append(UpdateOne({"symbol": i_new}, {'$set': {name: {"time": time_stamp, "4. close": data_curr_price[i]["currentprice"]}}}))
       else:
         # The first append here relates to the field daily_change. This will be overwritten every time.
         data_request.append(UpdateOne({"symbol": i}, {'$set': {"daily_change": data_curr_price[i]}}))
@@ -171,7 +175,7 @@ def handler(event,context):
     # create the array with all of the UpdateOne requests
     # get the current time and convert to the correct format YYYY-MM-DDTHH:MM:SS
     time_stamp = datetime.datetime.now()
-    time_stamp_str = time_stamp.strftime('%Y-%m-%dT%H:%M:%S')
+    time_stamp_str = time_stamp.strftime('%Y-%m-%dT%H:%M')
     requests_database = create_data_request(data_current_price, time_stamp_str)
 
     # write these requests to the Database

--- a/amplify/backend/function/stockPriceIntraDay/src/index.py
+++ b/amplify/backend/function/stockPriceIntraDay/src/index.py
@@ -173,7 +173,7 @@ def handler(event,context):
   
   try:
     # create the array with all of the UpdateOne requests
-    # get the current time and convert to the correct format YYYY-MM-DDTHH:MM:SS
+    # get the current time and convert to the correct format YYYY-MM-DDTHH:MM
     time_stamp = datetime.datetime.now()
     time_stamp_str = time_stamp.strftime('%Y-%m-%dT%H:%M')
     requests_database = create_data_request(data_current_price, time_stamp_str)


### PR DESCRIPTION
Format of the date is coming in with seconds so needed to be updated to remove the seconds. 

Daragh also noted that the data for BF-B had the same issue as BRK-B.