### PR TITLE
Changed port from 3000 to 3001

### DIFF
--- a/amplify/backend/function/expressServer/src/app.js
+++ b/amplify/backend/function/expressServer/src/app.js
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License"). You may not use 
 or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
 */
-const port = 3000;
+const port = 3001;
 const express = require('express');
 const bodyParser = require('body-parser');
 const awsServerlessExpressMiddleware = require('aws-serverless-express/middleware');


### PR DESCRIPTION
To try and combat the error of the port being in use already. Also for local dev React uses port 3000 this will fix this issue.

![image](https://user-images.githubusercontent.com/61060096/197803646-2b7d2856-7ea6-4823-b2cb-96d3c3fc1771.png)



 Everyone needs to update there aws-exports.js file to this once its approved . 

![image](https://user-images.githubusercontent.com/61060096/197803120-5e10f0c8-73fe-4df6-ae11-ebfc8bdf678c.png)
