### PR TITLE
Upadted lambada expressJS function to have a memory size of 3000 Mb

### DIFF
--- a/amplify/backend/function/expressServer/expressServer-cloudformation-template.json
+++ b/amplify/backend/function/expressServer/expressServer-cloudformation-template.json
@@ -79,6 +79,7 @@
           ]
         },
         "Runtime": "nodejs14.x",
+        "MemorySize": 3000,
         "Layers": [],
         "Timeout": 25
       }


### PR DESCRIPTION
Memory of express server will be updated to 3000Mb from 128Mb 