### PR TITLE
Stock discovery screen revamp

### DIFF
--- a/src/components/stockDiscoveryComponents/stockSearchResults/StockSearchResults.js
+++ b/src/components/stockDiscoveryComponents/stockSearchResults/StockSearchResults.js
@@ -37,6 +37,7 @@ function StockSearchResults({keyword}) {
         {loading ? <LoadingSpinner /> : error  ? <MessageAlert variant='danger'>{error}</MessageAlert> :
         Object.keys(stocks).length !== 0  ?
         <>
+        <div className="stocksearchresults">
         <h3 className="stockdiscoveryRow">Showing Results for "{keyword.trim()}"</h3>
         <Container>
         <Row md={1} xs={1}>
@@ -49,12 +50,14 @@ function StockSearchResults({keyword}) {
             </SideScrollMenu>
          
          </Row>
-         </Container>       
+         </Container>     
+         </div>  
         </> :
     
         <>
         <MessageAlert variant='danger'>No results match your search term "{keyword}"</MessageAlert>
         </>
+      
          
         }</>
                            

--- a/src/components/stockDiscoveryComponents/stockSearchResults/StockSearchResults.js
+++ b/src/components/stockDiscoveryComponents/stockSearchResults/StockSearchResults.js
@@ -39,7 +39,7 @@ function StockSearchResults({keyword}) {
         <>
         <div className="stocksearchresults">
         <h3 className="stockdiscoveryRow">Showing Results for "{keyword.trim()}"</h3>
-        <Container>
+
         <Row md={1} xs={1}>
             <SideScrollMenu>
                 {stocks.map((stockObj) => (
@@ -50,7 +50,7 @@ function StockSearchResults({keyword}) {
             </SideScrollMenu>
          
          </Row>
-         </Container>     
+ 
          </div>  
         </> :
     

--- a/src/screens/stockDiscovery/stockDiscoveryScreen.js
+++ b/src/screens/stockDiscovery/stockDiscoveryScreen.js
@@ -16,7 +16,7 @@ function StockDiscoveryPage(){
     return(<>
     <div className="stockDiscovery">
             <Container>
-                <h1 style={{textAlign:"center"}}>Stock Discovery</h1>
+                {/* <h1 style={{textAlign:"center"}}>Stock Discovery</h1> */}
 
                 <StockSearchBar/>
                 </Container>

--- a/src/screens/stockDiscovery/stockDiscoveryScreen.js
+++ b/src/screens/stockDiscovery/stockDiscoveryScreen.js
@@ -21,13 +21,16 @@ function StockDiscoveryPage(){
                 <StockSearchBar/>
                 </Container>
                 {keyword === undefined ? (
-                    <Row md={1} xs={1}>
+                    <Row md={1} xs={1}
+                    >
                         <StockSummary/>
                     </Row>
                    
                 ) : (
                     <Row md={1} xs={1}>
+                        <Container>
                           <StockSearchResults keyword={keyword}/>
+                          </Container>
                     </Row>
                 )}
                 </div>

--- a/src/screens/stockDiscovery/stockDiscoveryScreen.js
+++ b/src/screens/stockDiscovery/stockDiscoveryScreen.js
@@ -13,10 +13,13 @@ import StockSearchResults from "../../components/stockDiscoveryComponents/stockS
 function StockDiscoveryPage(){
     // keyword wil either be a word or undefiened, its used in search 
     let {keyword} = useParams()
-    return(
+    return(<>
+    <div className="stockDiscovery">
             <Container>
                 <h1 style={{textAlign:"center"}}>Stock Discovery</h1>
+
                 <StockSearchBar/>
+                </Container>
                 {keyword === undefined ? (
                     <Row md={1} xs={1}>
                         <StockSummary/>
@@ -27,7 +30,8 @@ function StockDiscoveryPage(){
                           <StockSearchResults keyword={keyword}/>
                     </Row>
                 )}
-            </Container>
+                </div>
+</>
     )
     }
 

--- a/src/scss/global_variables.scss
+++ b/src/scss/global_variables.scss
@@ -17,4 +17,4 @@ $info: #595959;
 $shadow: #c0c0c0;
 $midgrey: #808080;
 
-$stockdiscoverybackground:  rgb(246, 246, 246);
+$stockdiscoverybackground:  rgb(230, 230, 230);

--- a/src/scss/global_variables.scss
+++ b/src/scss/global_variables.scss
@@ -15,4 +15,6 @@ $neutralSentiment: #FFA500;
 // used in widgetsComponents/infobutten.scss for infobutton
 $info: #595959;
 $shadow: #c0c0c0;
-$midgrey: #808080
+$midgrey: #808080;
+
+$stockdiscoverybackground:  rgb(246, 246, 246);

--- a/src/scss/global_variables.scss
+++ b/src/scss/global_variables.scss
@@ -17,4 +17,5 @@ $info: #595959;
 $shadow: #c0c0c0;
 $midgrey: #808080;
 
-$stockdiscoverybackground:  rgb(230, 230, 230);
+$stockdiscoverybackground: white
+//  rgb(230, 230, 230);

--- a/src/scss/stockComponents/stockCardContainer.scss
+++ b/src/scss/stockComponents/stockCardContainer.scss
@@ -23,7 +23,8 @@
   width: 10rem;
   height: 100%;
   display: block;
-  border-color:rgb(224, 224, 224);
+  border:none;
+  // border-color:rgb(224, 224, 224);
 }
 
 @media only screen and (min-width: 500px) {

--- a/src/scss/stockComponents/stockCardContainer.scss
+++ b/src/scss/stockComponents/stockCardContainer.scss
@@ -23,6 +23,9 @@
   width: 10rem;
   height: 100%;
   display: block;
+  border-width: 1.5px;
+  border-color: $shadow;
+  box-shadow: 2px 2px $shadow;
 }
 
 @media only screen and (min-width: 500px) {

--- a/src/scss/stockComponents/stockCardContainer.scss
+++ b/src/scss/stockComponents/stockCardContainer.scss
@@ -35,9 +35,14 @@
 }
 
 .stockdiscoveryRow {
+  margin:1rem;
   margin-top: 2rem;
   margin-left: 2rem;
+  padding-right: 1rem;
   background-color: $stockdiscoverybackground;
+  white-space: initial;
+  word-wrap: break-word;
+  width:90%;
 }
 
 .tickerCardImgContainer {

--- a/src/scss/stockComponents/stockCardContainer.scss
+++ b/src/scss/stockComponents/stockCardContainer.scss
@@ -23,8 +23,6 @@
   width: 10rem;
   height: 100%;
   display: block;
-  border:none;
-  // border-color:rgb(224, 224, 224);
 }
 
 @media only screen and (min-width: 500px) {

--- a/src/scss/stockComponents/stockCardContainer.scss
+++ b/src/scss/stockComponents/stockCardContainer.scss
@@ -22,7 +22,8 @@
 .tickercardstyle {
   width: 10rem;
   height: 100%;
-  display: block
+  display: block;
+  border-color:rgb(224, 224, 224);
 }
 
 @media only screen and (min-width: 500px) {
@@ -34,6 +35,8 @@
 
 .stockdiscoveryRow {
   margin-top: 2rem;
+  margin-left: 2rem;
+  background-color: $stockdiscoverybackground;
 }
 
 .tickerCardImgContainer {

--- a/src/scss/widgetsComponents/sideScroll.scss
+++ b/src/scss/widgetsComponents/sideScroll.scss
@@ -22,7 +22,7 @@
     background-color:$stockdiscoverybackground;
   }
   ::-webkit-scrollbar-thumb {
-    background: $shadow;
+    background: $info;
     border-radius: 100vw;
     border: .20em solid $stockdiscoverybackground;
   

--- a/src/scss/widgetsComponents/sideScroll.scss
+++ b/src/scss/widgetsComponents/sideScroll.scss
@@ -15,7 +15,27 @@
 
 .stockDiscovery {
   background-color: $stockdiscoverybackground;
-  // height:50vw;
+  overflow:hidden;
+  .cardContainer{
+    padding-left: 2rem;
+    padding-right: 2rem;
+    background-color:$stockdiscoverybackground;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: $info;
+    border-radius: 100vw;
+    border: .20em solid $stockdiscoverybackground;
+  
+  }
+  ::-webkit-scrollbar-track {
+    background: $stockdiscoverybackground;
+    margin-inline-start: 2rem;
+    margin-inline-end: 2rem;
+  }
+}
+.stocksearchresults{
+  background-color: $stockdiscoverybackground;
+  height:100vh;
   .cardContainer{
     padding-left: 2rem;
     padding-right: 2rem;

--- a/src/scss/widgetsComponents/sideScroll.scss
+++ b/src/scss/widgetsComponents/sideScroll.scss
@@ -22,7 +22,7 @@
     background-color:$stockdiscoverybackground;
   }
   ::-webkit-scrollbar-thumb {
-    background: $info;
+    background: $shadow;
     border-radius: 100vw;
     border: .20em solid $stockdiscoverybackground;
   
@@ -42,7 +42,7 @@
     background-color:$stockdiscoverybackground;
   }
   ::-webkit-scrollbar-thumb {
-    background: $info;
+    background: $shadow;
     border-radius: 100vw;
     border: .20em solid $stockdiscoverybackground;
   

--- a/src/scss/widgetsComponents/sideScroll.scss
+++ b/src/scss/widgetsComponents/sideScroll.scss
@@ -1,13 +1,35 @@
+@import "../global_variables.scss";
+
 .cardContainer {
   display: flex;
   overflow-x: auto;
   overflow-y: hidden;
   height: 100%;
-
   .sideScrollCard {
     display: inline-block;
     padding: 0.1875rem;
     padding-top:0;
   }
 
+}
+
+.stockDiscovery {
+  background-color: $stockdiscoverybackground;
+  // height:50vw;
+  .cardContainer{
+    padding-left: 2rem;
+    padding-right: 2rem;
+    background-color:$stockdiscoverybackground;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: $shadow;
+    border-radius: 100vw;
+    border: .20em solid $stockdiscoverybackground;
+  
+  }
+  ::-webkit-scrollbar-track {
+    background: $stockdiscoverybackground;
+    margin-inline-start: 2rem;
+    margin-inline-end: 2rem;
+  }
 }


### PR DESCRIPTION
Its the weekend so theres no need to review this until Monday.

Changed up the stock discovery screen as per Andreas comments. I basically widened the containers to fit the entire screen with padding on either end.  I tried changing the background colour but I felt it looked a bit dirty, so I left it as is for now, but can always change it to a background color with no border on the cards if you think its bettter

Let me know what you think.
![image](https://user-images.githubusercontent.com/78801723/204048176-f80f9ad3-ee9a-43c3-9436-6eb5aa16eb96.png)
![image](https://user-images.githubusercontent.com/78801723/204048385-8f0684bb-3e3f-4d4e-9d91-78204c974cbb.png)


Attempt with background color changed:
![image](https://user-images.githubusercontent.com/78801723/204044224-7515599f-d340-44cb-a03b-4925eeb7206f.png)



