### PR TITLE
Trade page portfolio selection

### DIFF
--- a/src/components/confirmOrderComponents/balanceComponent.js
+++ b/src/components/confirmOrderComponents/balanceComponent.js
@@ -1,7 +1,7 @@
 import { Card, Container } from "react-bootstrap";
 import { Pie, PieChart, Cell, ResponsiveContainer, Label } from "recharts";
 
-function BalanceComponent({ newPortfolioBalance, amountSelected, portfolioBalance }) {
+function BalanceComponent({ portfolioName, newPortfolioBalance, amountSelected, portfolioBalance }) {
     const data = [{ value: amountSelected }, { value: newPortfolioBalance }];
 
     const CustomLabel = ({ viewBox, balance = 0 }) => {
@@ -25,7 +25,7 @@ function BalanceComponent({ newPortfolioBalance, amountSelected, portfolioBalanc
             <Card>
                 <Container>
                     <h5 style={{ marginTop: "10px" }}>New Portfolio Balance</h5>
-                    <p><strong>Portfolio A </strong>- Available Balance: ${portfolioBalance}</p>
+                    <p><strong>{portfolioName}</strong>- Available Balance: ${portfolioBalance}</p>
                     <ResponsiveContainer width="100%" height={300} margin={100}>
 
                         <PieChart height={260} width={500}>

--- a/src/components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown.js
+++ b/src/components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown.js
@@ -1,0 +1,22 @@
+import {Dropdown } from "react-bootstrap";
+
+function PortfolioSelectionDropdown({portfolios, onClick}){
+    return (
+        <Dropdown className="dropdownStyle">
+        <Dropdown.Toggle variant="success" id="dropdown-basic" size="sm">
+            Select Portfolio
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+            {portfolios.map(portfolio => (
+                <Dropdown.Item
+                    value={portfolio.name}
+                    id={portfolio.name}
+                    key={portfolio.name}
+                    onClick={onClick}>{portfolio.name}</Dropdown.Item>
+            ))}
+        </Dropdown.Menu>
+    </Dropdown>
+    )
+}
+
+export default PortfolioSelectionDropdown

--- a/src/components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown.js
+++ b/src/components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown.js
@@ -1,20 +1,28 @@
-import {Dropdown } from "react-bootstrap";
+import {Dropdown} from "react-bootstrap";
 
-function PortfolioSelectionDropdown({portfolios, onClick}){
+function PortfolioSelectionDropdown({portfolios, state, setState}){
+
+    function onSelectHandler(e){
+        setState(e)
+    }
+
     return (
-        <Dropdown className="dropdownStyle">
+        <Dropdown className="dropdownStyle" onSelect={onSelectHandler}>
         <Dropdown.Toggle variant="success" id="dropdown-basic" size="sm">
             Select Portfolio
         </Dropdown.Toggle>
-        <Dropdown.Menu>
+            <Dropdown.Menu>
             {portfolios.map(portfolio => (
                 <Dropdown.Item
-                    value={portfolio.name}
-                    id={portfolio.name}
-                    key={portfolio.name}
-                    onClick={onClick}>{portfolio.name}</Dropdown.Item>
-            ))}
-        </Dropdown.Menu>
+                    value={portfolio}
+                    id={portfolio.portfolioName}
+                    key={portfolio.portfolioName}
+                    eventKey={portfolio._id}
+                    >
+                        {portfolio.portfolioName}
+                </Dropdown.Item>
+            ))} 
+            </Dropdown.Menu>
     </Dropdown>
     )
 }

--- a/src/components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown.js
+++ b/src/components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown.js
@@ -12,11 +12,11 @@ function PortfolioSelectionDropdown({portfolios, state, setState}){
             Select Portfolio
         </Dropdown.Toggle>
             <Dropdown.Menu>
-            {portfolios.map(portfolio => (
+            {portfolios.map((portfolio,idx) => (
                 <Dropdown.Item
                     value={portfolio}
-                    id={portfolio.portfolioName}
-                    key={portfolio.portfolioName}
+                    id={`${portfolio.portfolioName}-${idx}`}
+                    key={`${portfolio.portfolioName}-${idx}`}
                     eventKey={portfolio.leagueId}
                     active={state === portfolio.leagueId} 
                     >

--- a/src/components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown.js
+++ b/src/components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown.js
@@ -18,6 +18,7 @@ function PortfolioSelectionDropdown({portfolios, state, setState}){
                     id={portfolio.portfolioName}
                     key={portfolio.portfolioName}
                     eventKey={portfolio._id}
+                    active={state === portfolio._id} 
                     >
                         {portfolio.portfolioName}
                 </Dropdown.Item>

--- a/src/components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown.js
+++ b/src/components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown.js
@@ -17,8 +17,8 @@ function PortfolioSelectionDropdown({portfolios, state, setState}){
                     value={portfolio}
                     id={portfolio.portfolioName}
                     key={portfolio.portfolioName}
-                    eventKey={portfolio._id}
-                    active={state === portfolio._id} 
+                    eventKey={portfolio.leagueId}
+                    active={state === portfolio.leagueId} 
                     >
                         {portfolio.portfolioName}
                 </Dropdown.Item>

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -9,6 +9,10 @@ import BalanceComponent from "../../components/confirmOrderComponents/balanceCom
 import OrderSummary from "../../components/confirmOrderComponents/OrderSummary";
 import LimitQuantitySelect from "../../components/confirmOrderComponents/LimitQuantitySelect";
 import LimitPriceSelect from "../../components/confirmOrderComponents/LimitPriceSelect";
+import PortfolioSelectionDropdown from "../../components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown";
+
+
+
 /// API ///
 import { APIName } from '../../constants/APIConstants'
 import { API } from "aws-amplify";
@@ -72,7 +76,7 @@ function OrderConfirmationPage() {
         <>
             {loading ? <LoadingSpinner /> : error ? <MessageAlert variant='danger'>{error}</MessageAlert> :
                 <Container>
-                    <Row>
+                    <Row md={3} sm={2} xs={2}>
                         <Col className="col-md-3 col-sm-3 col-3">
                             <img src={stock.logo} className="img-fluid" alt="Company Logo" style={{ width: "100%", paddingTop: "1.25rem" }} />
                         </Col>
@@ -87,6 +91,9 @@ function OrderConfirmationPage() {
                                 <dt style={{ fontSize: "150%" }}>${stock.daily_change.currentprice.toFixed(2)}
                                 </dt>
                             </dl>
+                        </Col>
+                        <Col>
+                            <PortfolioSelectionDropdown/>
                         </Col>
                     </Row>
                     <Col style={{ marginBottom: "0.625rem" }}>

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -33,7 +33,7 @@ function OrderConfirmationPage() {
     const [isShownMarketOrder, setIsShownMarketOrder] = useState(false)
     const [isShownLimitOrder, setIsShownLimitOrder] = useState(false)
     const [limitPrice, setLimitPrice] = useState(0)
-    const [portfolio, setPortfolio] = useState()
+    const [portfolioId, setPortfolioId] = useState()
 
     /// Redux ///
     const portfolios = useSelector((state) => state.portfolios)
@@ -81,8 +81,8 @@ function OrderConfirmationPage() {
 
     useEffect(() => {
         console.log("Called")
-        console.log(portfolio)
-    },[portfolio])
+        console.log(portfolioId)
+    },[portfolioId])
 
 
 
@@ -110,7 +110,7 @@ function OrderConfirmationPage() {
                             </dl>
                         </Col>
                         <Col>
-                            <PortfolioSelectionDropdown portfolios={activePortfolios} setState={setPortfolio}/>
+                            <PortfolioSelectionDropdown portfolios={activePortfolios} state={portfolioId} setState={setPortfolioId}/>
                         </Col>
                     </Row>
                     <Col style={{ marginBottom: "0.625rem" }}>

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -11,7 +11,8 @@ import LimitQuantitySelect from "../../components/confirmOrderComponents/LimitQu
 import LimitPriceSelect from "../../components/confirmOrderComponents/LimitPriceSelect";
 import PortfolioSelectionDropdown from "../../components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown";
 
-
+/// Redux ///
+import {useSelector} from 'react-redux';
 
 /// API ///
 import { APIName } from '../../constants/APIConstants'
@@ -32,6 +33,12 @@ function OrderConfirmationPage() {
     const [isShownMarketOrder, setIsShownMarketOrder] = useState(false)
     const [isShownLimitOrder, setIsShownLimitOrder] = useState(false)
     const [limitPrice, setLimitPrice] = useState(0)
+    const [portfolio, setPortfolio] = useState()
+
+    /// Redux ///
+    const portfolios = useSelector((state) => state.portfolios)
+    const { activePortfolios } = portfolios;
+
 
     useEffect(() => {
         /// getStockInfo ///
@@ -72,6 +79,16 @@ function OrderConfirmationPage() {
     }, [orderType])
 
 
+    useEffect(() => {
+        console.log("Called")
+        console.log(portfolio)
+    },[portfolio])
+
+
+
+
+    
+
     return (
         <>
             {loading ? <LoadingSpinner /> : error ? <MessageAlert variant='danger'>{error}</MessageAlert> :
@@ -93,7 +110,7 @@ function OrderConfirmationPage() {
                             </dl>
                         </Col>
                         <Col>
-                            <PortfolioSelectionDropdown/>
+                            <PortfolioSelectionDropdown portfolios={activePortfolios} setState={setPortfolio}/>
                         </Col>
                     </Row>
                     <Col style={{ marginBottom: "0.625rem" }}>

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -21,11 +21,13 @@ import { API } from "aws-amplify";
 
 function OrderConfirmationPage() {
 
-    const portfolioBalance = 2000
+
+    /// Stock State ///
     const [stockLoading, setStockLoading] = useState(true);
     const [stock, setStock] = useState('');
     const [error, setError] = useState("");
     
+    /// Order State ////
     const [amountSelected, setAmountSelected] = useState("")
     const [buyOrSell, setBuyOrSell] = useState("Buy");
     const [orderType, setOrderType] = useState("Market Order");
@@ -36,15 +38,14 @@ function OrderConfirmationPage() {
    
 
     //// Portfolio State ////
+    const [portfolio, setPortfolio] = useState({})
     const [portfolioId, setPortfolioId] = useState()
     const [portfolioLoading, setPortfolioLoading] = useState(true)
     const [portfolioError, setPortfolioError] = useState()
-    const [newPortfolioBalance, setNewPortfolioBalance] = useState(portfolioBalance)
+    const [newPortfolioBalance, setNewPortfolioBalance] = useState()
+    
 
-
-
-
-    /// Redux ///
+    /// Redux State ///
     const portfolios = useSelector((state) => state.portfolios)
     const {activePortfolios, loading} = portfolios;
     const user = useSelector((state) => state.user)
@@ -102,10 +103,16 @@ function OrderConfirmationPage() {
                 let myInit = {
                     headers : {"x-auth-token": userToken},       
                 }
-                console.log(path)
                 /// Send the request 
                 const res = await API.get(APIName, path, myInit)
                 console.log(res)
+                /// Set the current portfolio 
+                setPortfolio({
+                    portfolioName: res.portfolioName,
+                    portfolioBalance: res.remainder
+                })
+                /// Set the Iitiliase the new portfolio balance to the remainder of the current 
+                setNewPortfolioBalance(res.remainder)
                 setPortfolioLoading(false)
             }catch(error){
                 console.log(error)
@@ -149,7 +156,7 @@ function OrderConfirmationPage() {
                                 </dt>
                             </dl>
                         </Col>
-                        <Col>
+                        <Col className="pb-2 pt-3">
                             <PortfolioSelectionDropdown portfolios={activePortfolios} state={portfolioId} setState={setPortfolioId}/>
                         </Col>
                     </Row>
@@ -163,7 +170,7 @@ function OrderConfirmationPage() {
                         <>
                             <Col style={{ marginBottom: "0.625rem" }}>
                                 <QuantitySelect
-                                    portfolioBalance={portfolioBalance}
+                                    portfolioBalance={portfolio.portfolioBalance}
                                     stockprice={stock.daily_change.currentprice}
                                     setNewPortfolioBalance={setNewPortfolioBalance}
                                     setAmountSelected={setAmountSelected}
@@ -172,7 +179,8 @@ function OrderConfirmationPage() {
                             </Col>
                             <Col style={{ marginBottom: "0.625rem" }}>
                                 <BalanceComponent
-                                    portfolioBalance={portfolioBalance}
+                                    portfolioName={portfolio.portfolioName}
+                                    portfolioBalance={portfolio.portfolioBalance}
                                     newPortfolioBalance={newPortfolioBalance}
                                     amountSelected={amountSelected}
                                 />
@@ -183,7 +191,7 @@ function OrderConfirmationPage() {
                         <>
                             <Col style={{ marginBottom: "0.625rem" }}>
                                 <LimitQuantitySelect
-                                    portfolioBalance={portfolioBalance}
+                                    portfolioBalance={portfolio.portfolioBalance}
                                     setQty={setQty}
                                     limitPrice={limitPrice}
                                     setAmountSelected={setAmountSelected}
@@ -192,7 +200,7 @@ function OrderConfirmationPage() {
                             </Col>
                             <Col style={{ marginBottom: "0.625rem" }}>
                                 <LimitPriceSelect
-                                    portfolioBalance={portfolioBalance}
+                                    portfolioBalance={portfolio.portfolioBalance}
                                     setAmountSelected={setAmountSelected}
                                     qty={qty}
                                     setLimitPrice={setLimitPrice}

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -19,10 +19,10 @@ import { APIName } from '../../constants/APIConstants'
 import { API } from "aws-amplify";
 
 
-function OrderConfirmationPage() {
+function OrderConfirmationPage({}) {
 
     const portfolioBalance = 2000
-    const [loading, setLoading] = useState(true);
+    const [stockLoading, setStockLoading] = useState(true);
     const [stock, setStock] = useState('');
     const [error, setError] = useState("");
     const [newPortfolioBalance, setNewPortfolioBalance] = useState(portfolioBalance)
@@ -37,7 +37,7 @@ function OrderConfirmationPage() {
 
     /// Redux ///
     const portfolios = useSelector((state) => state.portfolios)
-    const { activePortfolios } = portfolios;
+    const {activePortfolios } = portfolios;
 
 
     useEffect(() => {
@@ -47,7 +47,7 @@ function OrderConfirmationPage() {
         const getStockInfo = async () => {
             try {
                 // Request is being sent set loading true   
-                setLoading(true);
+                setStockLoading(true);
                 // get the symbol from the url string, use regex to extract capital letters only
                 const symbol = window.location.href.replace(/[^A-Z]/g, '');
                 // Set the path and use symbol to get single stock
@@ -56,11 +56,11 @@ function OrderConfirmationPage() {
                 const res = await API.get(APIName, path)
                 // Set the state for the stock and loading to false 
                 setStock(res)
-                setLoading(false)
+                setStockLoading(false)
             } catch (error) {
                 // Set the error message to be displayed on the page 
                 setError(error.response.data.errormessage)
-                setLoading(false)
+                setStockLoading(false)
             }
         }
         getStockInfo();
@@ -80,8 +80,7 @@ function OrderConfirmationPage() {
 
 
     useEffect(() => {
-        console.log("Called")
-        console.log(portfolioId)
+
     },[portfolioId])
 
 
@@ -91,7 +90,7 @@ function OrderConfirmationPage() {
 
     return (
         <>
-            {loading ? <LoadingSpinner /> : error ? <MessageAlert variant='danger'>{error}</MessageAlert> :
+            {stockLoading ? <LoadingSpinner /> : error ? <MessageAlert variant='danger'>{error}</MessageAlert> :
                 <Container>
                     <Row md={3} sm={2} xs={2}>
                         <Col className="col-md-3 col-sm-3 col-3">

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -11,6 +11,8 @@ import LimitQuantitySelect from "../../components/confirmOrderComponents/LimitQu
 import LimitPriceSelect from "../../components/confirmOrderComponents/LimitPriceSelect";
 import PortfolioSelectionDropdown from "../../components/portfolioComponents/portfolioSelectionDropdown/portfolioSelectionDropdown";
 
+import {useNavigate} from "react-router-dom"
+
 /// Redux ///
 import {useSelector} from 'react-redux';
 
@@ -51,6 +53,9 @@ function OrderConfirmationPage() {
     const user = useSelector((state) => state.user)
     const { userInfo } = user;
     const userToken = userInfo.token
+
+    /// naviagte - to redirect 
+    const navigate = useNavigate()
 
 
     useEffect(() => {
@@ -122,8 +127,13 @@ function OrderConfirmationPage() {
         }
         /// Need to set an intial value ///
         if (typeof portfolioId === "undefined" && loading === false){
-            /// For now set the current portfolio to the first portfolio may need to revisit this ///
-            setPortfolioId(activePortfolios[0].leagueId)
+            /// Add in a savety check here if a user naviagtes to the page by typing in url redirect them to the game screen
+            if (activePortfolios.length === 0){
+                navigate(`/game`)
+            }else{
+              /// For now set the current portfolio to the first portfolio may need to revisit this ///
+            setPortfolioId(activePortfolios[0].leagueId)  
+            }
         }else if(portfolioId){
             /// Get the portfolio data 
             getPortfolioInfo()

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -110,7 +110,6 @@ function OrderConfirmationPage() {
                 }
                 /// Send the request 
                 const res = await API.get(APIName, path, myInit)
-                console.log(res)
                 /// Set the current portfolio 
                 setPortfolio({
                     portfolioName: res.portfolioName,
@@ -138,7 +137,7 @@ function OrderConfirmationPage() {
             /// Get the portfolio data 
             getPortfolioInfo()
         }
-    },[portfolioId,activePortfolios,loading, userToken])
+    },[portfolioId,activePortfolios,loading, userToken,navigate])
 
 
 


### PR DESCRIPTION
This PR deals with the portfolio selection logic and request to backend, things on trade page may look a bit out of place weird style but just want to focus on getting to testing Joey's Buy/Sell routes and maybe fix styling later. 

New component called ```portfolioSelectionDropdown```, used to set the state of current portfolio on the screen. 

Request is sent to the route ```GET /api/portfolio/:legueID``` to get the given portfolio associated with the league. 
Current portfolio then stored in state in ```orderConfirmationScreen```

I have added in a check which will redirect the user to the ```/game``` route if they attempt to type in the confirm order route in the address bar when they have no active portfolios. This at the moment causes when yu click ```Lets Trade``` to be directly redirected to the ```Game``` page in this PR's branch but when the [popup PR](https://github.com/DaraghK93/stockApp/pull/558) is merged it will be fixed. 

![image](https://user-images.githubusercontent.com/61060096/204612226-dbdbc665-37ed-4318-a3b9-4cb330146130.png)
![image](https://user-images.githubusercontent.com/61060096/204612333-fda9ceb9-80cd-46d4-9ced-1afaf1d283d9.png)

# Testing 
To test choosing a portfolio try creating a few active games, they should appear in the dropdown menu. 
