### PR TITLE
Quickfix to hardcoded API call

### DIFF
--- a/amplify/backend/function/expressServer/src/controllers/stockController.js
+++ b/amplify/backend/function/expressServer/src/controllers/stockController.js
@@ -47,7 +47,7 @@ const getAllStocks = async (req, res, next) => {
     /// if undefined return the stock summary 
     if(keyword == "undefined"){     
       // For now, this is hardcoded to give 20 recommendations for Disney (DIS). This will be updated tomorrow based on the user's owned stocks. Some console logs have also been left in commented out to make integration and troubleshooting this easier.
-      let recommendData = await stockService.getRecomms("DIS")
+      let recommendData = await stockService.getRecomms("ObjectId('6387ac24d9cd712b834670cb')")
       // console.log("Recommended Data (Promise): ",recommendData.data.message)
       let recs = recommendData.data.message
       // const rec_function = stockService.getStockSummaryRecs(recs)

--- a/amplify/backend/function/expressServer/src/services/stockRoutesServices.js
+++ b/amplify/backend/function/expressServer/src/services/stockRoutesServices.js
@@ -92,9 +92,9 @@ function getStockPriceData (stocks) {
 };
 
 // This function makes an API call to the API gateway for the recommender lambda function
-const getRecomms = async (stock) => {
+const getRecomms = async (userID) => {
     // This sets the body of the request to the stock ticker input. This will be changed to take in user ID in the next iteration.
-    var data = '{"stock":' + '"' + stock + '"}';
+    var data = '{"userid":' + '"' + userID + '"}';
     try {
       const resp = await axios({
         method: 'GET',


### PR DESCRIPTION
This is a quick fix to address the discovery page that was broken by the new recommender system deployment.

The problem - Page not loading because no value is returned when the API call is made. This was a necessary result of updating the lambda deployment:

![image](https://user-images.githubusercontent.com/78538312/204892072-f8a34ee0-35ad-4362-b97c-50881778d30e.png)

The fix - Updated the API to a new hardcoded value for a user account. This will then be updated and parametrised but I wanted to get something displaying tonight before logging off.

![image](https://user-images.githubusercontent.com/78538312/204892252-de30a07e-a1b4-4782-8998-9b6e3a2b1b76.png)