### PR TITLE
Jupyter Notebook language stats fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+machineLearning/stockRecommendationSystem/modelGeneration/dataExploration/data_explore.ipynb/** linguist-vendored
+machineLearning/stockRecommendationSystem/modelGeneration/model_1/model_1.ipynb/** linguist-vendored


### PR DESCRIPTION
This is a fix for the language statistics on the repo.
Currently shows as this despite there only being 2 Jupyter notebook files:
![image](https://user-images.githubusercontent.com/78538312/205050617-5c428767-c8f0-454f-81b0-7e96b9b8c1d3.png)

Fixed using this method:
https://stackoverflow.com/questions/19052834/is-it-possible-to-exclude-files-from-git-language-statistics