### PR TITLE
Updated sort order of recommendations

### DIFF
--- a/amplify/backend/function/expressServer/src/services/stockRoutesServices.js
+++ b/amplify/backend/function/expressServer/src/services/stockRoutesServices.js
@@ -123,7 +123,9 @@ const stocks =  schema.aggregate([
                 'daily_change.currentprice': 1,
                 'esgrating.environment_score': 1
             }
-        }
+        },
+        {$addFields: {"order": {$indexOfArray: [recommended, "$symbol" ]}}},
+        {$sort: {"order": 1}}
         ],
         // agg query for top environment
         topEnvironment: [{$match :{}},{$project: {'symbol': 1,'longname': 1,'exchange':1,'logo':1,


### PR DESCRIPTION
# Changes:
- This change has updated the sort order of the recommendations to preserve the original cosine similarity order from the recommender API.
- It turns out when you use the $in Mongoose operator, it sorts the resulting array alphabetically by default. This was corrected by changing the sort order using the method found in this SO post: https://stackoverflow.com/questions/22797768/does-mongodbs-in-clause-guarantee-order/42293303#42293303. This basically works by appending a new attribute to each result and then sorting by that.

## Screenshot of API call showing correct cosine similarity ordering.
![image](https://user-images.githubusercontent.com/78538312/205677879-ec900475-e21a-47f2-99ec-c1f1ccfae874.png)

## Screenshot of the order change showing the correct order:
![image](https://user-images.githubusercontent.com/78538312/205678057-38a193a4-bba7-4519-8303-ee9f4a625d0a.png)
