### PR TITLE
Backend leave game

### DIFF
--- a/amplify/backend/function/expressServer/src/controllers/leagueController.js
+++ b/amplify/backend/function/expressServer/src/controllers/leagueController.js
@@ -575,6 +575,7 @@ const leaveLeague = async (req,res,next) => {
       )
     }
     const portfolio = await Portfolio.findOne({_id: req.body.portfolioId, leagueId: req.body.leagueId, userId: req.user.id}) 
+    // check if a portfolio with league ID and user ID in it
     if(portfolio === null){
       res.status(404)
       res.errormessage = 'No such portfolio exists.'
@@ -584,6 +585,7 @@ const leaveLeague = async (req,res,next) => {
         ),
       )
     }
+    // check if league exists with that portfolio and that user
     const league = await League.findOne({_id: req.body.leagueId, portfolios: req.body.portfolioId, users: req.user.id}) 
     if(league === null){
       res.status(404)
@@ -594,6 +596,7 @@ const leaveLeague = async (req,res,next) => {
         ),
       )
     }
+    // the league admin can't leave the league
     if(league.leagueAdmin === req.user.id){
       res.status(400)
       res.errormessage = 'The admin cannot leave the league.'
@@ -603,9 +606,13 @@ const leaveLeague = async (req,res,next) => {
         ),
       )
     }
+    // update the league, removing the portfolio and the user
     await League.findOneAndUpdate({_id: req.body.leagueId}, {$pull: {portfolios: req.body.portfolioId, users: portfolio.userId}})
+    // delete the portfolio
     await Portfolio.deleteOne({_id: req.body.portfolioId, leagueId: req.body.leagueId})
+    // update the user, removing the league and the portfolio
     const user = await User.findOneAndUpdate({_id: portfolio.userId}, {$pull: {portfolios: req.body.portfolioId, leagues: req.body.leagueId}})
+    // return the user
     res.json(user)
   }
 

--- a/amplify/backend/function/expressServer/src/controllers/leagueController.js
+++ b/amplify/backend/function/expressServer/src/controllers/leagueController.js
@@ -557,6 +557,31 @@ const getLeagueById = async (req,res,next) => {
 
 }
 
+const leaveLeague = async (req,res,next) => {
+  try{
+    if (
+      typeof req.body.portfolioId === 'undefined' 
+    ) {
+      // data is missing bad request
+      res.status(400)
+      res.errormessage = 'Missing portfolio ID needed to leave the league.'
+      return next(
+        new Error(
+          'The client has not sent the required portfolio ID to create a league'
+        ),
+      )
+    } 
+  }
+
+  catch (err) {
+    console.error(err.message);
+    res.errormessage = 'Server error in leaving a league'
+    res.status(500)
+    return next(err)
+  }
+
+}
+
 module.exports = {
     createLeague,
     getPublicLeagues,

--- a/amplify/backend/function/expressServer/src/controllers/leagueController.js
+++ b/amplify/backend/function/expressServer/src/controllers/leagueController.js
@@ -612,8 +612,10 @@ const leaveLeague = async (req,res,next) => {
     await Portfolio.deleteOne({_id: req.body.portfolioId, leagueId: req.body.leagueId})
     // update the user, removing the league and the portfolio
     const user = await User.findOneAndUpdate({_id: portfolio.userId}, {$pull: {portfolios: req.body.portfolioId, leagues: req.body.leagueId}})
-    // return the user
-    res.json(user)
+    // return success message
+    res.status(200).json({
+      message: 'You have successfully left the league.',
+    });
   }
 
   catch (err) {

--- a/amplify/backend/function/expressServer/src/controllers/leagueController.js
+++ b/amplify/backend/function/expressServer/src/controllers/leagueController.js
@@ -1,4 +1,5 @@
 const League = require('../models/league.model')
+const Portfolio = require('../models/portfolio.model')
 const leagueService = require('../services/leagueServices')
 
 const mongoose = require("mongoose")
@@ -570,7 +571,9 @@ const leaveLeague = async (req,res,next) => {
           'The client has not sent the required portfolio ID to create a league'
         ),
       )
-    } 
+    }
+    const portfolio = await Portfolio.findOne({_id: req.body.portfolioId, userId: req.user.id}) 
+    res.json(portfolio)
   }
 
   catch (err) {
@@ -587,5 +590,6 @@ module.exports = {
     getPublicLeagues,
     joinLeaguebyCode,
     getMyLeagues,
-    getLeagueById
+    getLeagueById,
+    leaveLeague
   }

--- a/amplify/backend/function/expressServer/src/controllers/userController.js
+++ b/amplify/backend/function/expressServer/src/controllers/userController.js
@@ -164,7 +164,6 @@ const loginUser = async (req, res, next) => {
       { expiresIn: 360000 },
       (err, token) => {
         if (err) throw err
-        console.log(token)
         res.json({
           firstname: user.firstname,
           lastname: user.lastname,

--- a/amplify/backend/function/expressServer/src/controllers/userController.js
+++ b/amplify/backend/function/expressServer/src/controllers/userController.js
@@ -164,6 +164,7 @@ const loginUser = async (req, res, next) => {
       { expiresIn: 360000 },
       (err, token) => {
         if (err) throw err
+        console.log(token)
         res.json({
           firstname: user.firstname,
           lastname: user.lastname,

--- a/amplify/backend/function/expressServer/src/routes/leagueRoutes.js
+++ b/amplify/backend/function/expressServer/src/routes/leagueRoutes.js
@@ -4,13 +4,14 @@ const express = require("express");
 const router = express.Router()
 const {protectedRoute} = require('../middleware/authMiddleware');
 
-const {createLeague, getPublicLeagues, joinLeaguebyCode, getMyLeagues,getLeagueById} = require('../controllers/leagueController');
+const {createLeague, getPublicLeagues, joinLeaguebyCode, getMyLeagues,getLeagueById, leaveLeague} = require('../controllers/leagueController');
 
 router.post('/createleague',protectedRoute,createLeague)
 router.get('/',protectedRoute, getPublicLeagues)
 router.get('/myleagues',protectedRoute,getMyLeagues)
 router.post('/joinleague',protectedRoute,joinLeaguebyCode)
 router.get('/:leagueId',protectedRoute,getLeagueById)
+router.post('/leaveLeague',protectedRoute,leaveLeague)
 
 
 

--- a/amplify/backend/function/expressServer/src/routes/leagueRoutes.js
+++ b/amplify/backend/function/expressServer/src/routes/leagueRoutes.js
@@ -11,7 +11,7 @@ router.get('/',protectedRoute, getPublicLeagues)
 router.get('/myleagues',protectedRoute,getMyLeagues)
 router.post('/joinleague',protectedRoute,joinLeaguebyCode)
 router.get('/:leagueId',protectedRoute,getLeagueById)
-router.post('/leaveLeague',protectedRoute,leaveLeague)
+router.post('/leaveLeague',leaveLeague)
 
 
 

--- a/amplify/backend/function/expressServer/src/routes/leagueRoutes.js
+++ b/amplify/backend/function/expressServer/src/routes/leagueRoutes.js
@@ -11,7 +11,7 @@ router.get('/',protectedRoute, getPublicLeagues)
 router.get('/myleagues',protectedRoute,getMyLeagues)
 router.post('/joinleague',protectedRoute,joinLeaguebyCode)
 router.get('/:leagueId',protectedRoute,getLeagueById)
-router.post('/leaveLeague',leaveLeague)
+router.post('/leaveLeague',protectedRoute, leaveLeague)
 
 
 


### PR DESCRIPTION
I've created a leaveLeague route now.

Admins can't leave their own leagues.

First create a league with one player and then join with another using the code and the route
http://localhost:3001/api/league/joinLeague (alternatively you can actually do this through your local app).

Then use http://localhost:3001/api/league/leaveleague to leave with the body looking like this
{
    "portfolioId": "638e2c525218379a73ab1602",
    "leagueId": "638e17f3dc9cd614a17d7c05"
    }

Hopefully this is ok.