### PR TITLE
backend for game stock page. type=all or type=summary

### DIFF
--- a/amplify/backend/function/expressServer/src/controllers/stockController.js
+++ b/amplify/backend/function/expressServer/src/controllers/stockController.js
@@ -191,13 +191,33 @@ const getStockBySymbol = async (req, res, next) => {
   }
 };
 
+// @route   GET api/stocks/gameStocks/game
+// @desc    Get stocks that are playable in a game
+// @access  Private - add auth middleware to make it private
 const getGameStocks = async (req, res, next) => {
   try{
-    // the game rules are sent in the request body
-    // this might need to be changed but is ok for now
-    // this gets the game summary
+    const type = req.params.type;
+    let gameStocks;
     const {sectors,minErating,minSRating,minGRating} = req.body
-    const gameStocks = await stockService.gameStockSummary(sectors,minErating,minSRating,minGRating)
+    
+    if (type === 'summary'){
+      // the game rules are sent in the request body
+      // this might need to be changed but is ok for now
+      // this gets the game summary
+      gameStocks = await stockService.gameStockSummary(sectors,minErating,minSRating,minGRating)
+    }
+    else if (type === 'all'){
+      //hardcoding 20 per page for all stocks at the minute can change if needed
+      const stocksPerPage = 20;
+      const pageNumber = req.body.pageNumber;
+      gameStocks = await stockService.getAllGameStocks(sectors,minErating,minSRating,minGRating,pageNumber,stocksPerPage);
+    }
+    else{
+      // No stock found
+      res.status(400);
+      res.errormessage = 'Invalid param entered';
+      return next(new Error('Invalid param entered'));
+    }
     
     // put the find all stocks here and pass the game rules to it
     // there will be an if statement that checks req.query and if it's 

--- a/amplify/backend/function/expressServer/src/controllers/stockController.js
+++ b/amplify/backend/function/expressServer/src/controllers/stockController.js
@@ -209,7 +209,11 @@ const getGameStocks = async (req, res, next) => {
     else if (type === 'all'){
       //hardcoding 20 per page for all stocks at the minute can change if needed
       const stocksPerPage = 20;
-      const pageNumber = req.body.pageNumber;
+      let pageNumber = req.body.pageNumber;
+      // if no page number included only show the first page
+      if(!pageNumber){
+        pageNumber =0
+      }
       gameStocks = await stockService.getAllGameStocks(sectors,minErating,minSRating,minGRating,pageNumber,stocksPerPage);
     }
     else{

--- a/amplify/backend/function/expressServer/src/routes/stockRoutes.js
+++ b/amplify/backend/function/expressServer/src/routes/stockRoutes.js
@@ -18,7 +18,7 @@ router.get('/', protectedRoute, getAllStocks)
 // search stock by ticker symbol. This will give all data except prices for that ticker
 router.get('/:symbol', getStockBySymbol)
 // get the stocks playable in a game
-router.get('/gameStocks/:type', getGameStocks)
+router.get('/gameStocks/:type', protectedRoute, getGameStocks)
 
 
 

--- a/amplify/backend/function/expressServer/src/routes/stockRoutes.js
+++ b/amplify/backend/function/expressServer/src/routes/stockRoutes.js
@@ -18,7 +18,7 @@ router.get('/', protectedRoute, getAllStocks)
 // search stock by ticker symbol. This will give all data except prices for that ticker
 router.get('/:symbol', getStockBySymbol)
 // get the stocks playable in a game
-router.get('/gameStocks/game', getGameStocks)
+router.get('/gameStocks/:type', getGameStocks)
 
 
 

--- a/amplify/backend/function/expressServer/src/services/stockRoutesServices.js
+++ b/amplify/backend/function/expressServer/src/services/stockRoutesServices.js
@@ -265,11 +265,29 @@ const gameStockSummary =  (sectors,minErating,minSRating,minGRating) => {
   return stocks
 }
 
+// gets the game stock summary to display on game stocks page
+const getAllGameStocks =  (sectors,minErating,minSRating,minGRating,pageNumber,pageSize) => {
+  const projectStatement = {'symbol': 1,'longname': 1,'exchange':1,'logo':1,
+                            'daily_change.absoluteChange':1,
+                            'daily_change.percentageChange':1,
+                            'daily_change.currentprice':1,
+                            'esgrating.environment_score': 1}
+
+  const amountToSkip = pageSize * pageNumber;
+  const stocks = Stock.find({'esgrating.environment_score':{$gte:minErating},
+    'esgrating.social_score':{$gte:minSRating},
+    'esgrating.governance_score':{$gte:minGRating},
+    'sector':{$in:sectors}}).select(projectStatement).skip(amountToSkip).limit(20)
+                        
+  return stocks
+}
+
 
 
 module.exports = {
     getStockPriceData,
     getStockSummary,
     getRecomms,
-    gameStockSummary
+    gameStockSummary,
+    getAllGameStocks
 }


### PR DESCRIPTION
Small enough PR building on from Daragh's start.

Backend for the game stock page finished. The route takes a param of 'all' or 'summary'. 'summary' matches the stock discovery page without the recommended stocks and the 'all' returns all tradable stocks.

Also in 'all' includes the basic pagination. Im hard-coding the page size to 20 for now but can easily change this depending on front-end needs.

TO TEST

http://localhost:3001/api/stock/gameStocks/all
OR
http://localhost:3001/api/stock/gameStocks/summary

SAMPLE BODY

{
"sectors": ["Technology"],
"minErating": 0,
"minSRating": 0,
"minGRating": 0,
"pageNumber": 0
}

Will move onto front-end then after this