### PR TITLE
Limit orders

### DIFF
--- a/src/components/confirmOrderComponents/BuyOrSell.js
+++ b/src/components/confirmOrderComponents/BuyOrSell.js
@@ -39,20 +39,4 @@ function BuyOrSell({state,setter,holding}){
 
 }
 
-
-//   {choices.map((radio, idx) => (
-//           <ToggleButton
-//             key={idx}
-//             id={`button-${idx}`}
-//             type="radio"
-//             variant='outline-primary'
-//             name="radio"
-//             value={radio.value}
-//             checked={state === radio.value}
-//             onChange={(e) => setter(e.currentTarget.value)}
-//           >
-//             {radio.name}
-//           </ToggleButton>
-//         ))}
-
 export default BuyOrSell;

--- a/src/components/confirmOrderComponents/LimitPriceSelect.js
+++ b/src/components/confirmOrderComponents/LimitPriceSelect.js
@@ -32,13 +32,6 @@ function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPr
 
     // const [price, setPrice] = useState(0);
 
-    // const sliderCall = (e) => {
-    //     setPrice(e.target.value)
-    //     setLimitPrice(e.target.value)
-    //     setAmountSelected(e.target.value * qty)
-    //     setNewPortfolioBalance(portfolioBalance - (e.target.value * qty))
-    // }
-
     return (
         <Card className="px-3">
             <h5 style={{ marginTop: "10px"}}>Price</h5>
@@ -54,7 +47,9 @@ function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPr
                         startWidth={"2rem"}
                         showError={false}
                         reset={buyOrSell}
-                        resetValue={"1"}
+                        resetValue={
+                            buyOrSell === "Buy"? "1" : stockPrice+1
+                            }
                     />
                 </Card.Body>
         </Card>

--- a/src/components/confirmOrderComponents/LimitPriceSelect.js
+++ b/src/components/confirmOrderComponents/LimitPriceSelect.js
@@ -15,12 +15,20 @@ function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPr
             // Max is dollar off the current stock price  
             setMax(stockPrice-1)
         }else if (buyOrSell === "Sell"){
-            setMin(stockPrice+1)
-            setMax(stockPrice*1.15)
+            setMin(Math.ceil(stockPrice))
+            // setMax(stockPrice*1.15)
+            setMax(Math.floor(stockPrice*1.15))
         }
         /// Check for errors 
         if (limitPrice > max){
-            setLimitOrderPriceError(`Price over ${parseFloat(max).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}, try market buy if you want this price!`)
+            /// Limit price greater than the max
+            if (buyOrSell === "Buy"){
+                /// For Buy it means that it is too close to the current stock price
+                setLimitOrderPriceError(`Price over ${parseFloat(max).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}, try market buy if you want this price!`)
+            }else if (buyOrSell === "Sell"){
+                /// For a sell it means you are trying to increase it above 15% growth 
+                setLimitOrderPriceError(`It's ambitious but prices over ${parseFloat(max).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} are too far from current price of ${parseFloat(stockPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}!`)
+            }
         }else if(limitPrice < min){
             setLimitOrderPriceError(`Price must be at least ${parseFloat(min).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}, try moving the slider to the right!`)
         }else{
@@ -30,7 +38,6 @@ function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPr
 
     },[buyOrSell,setMin,setMax,stockPrice,max,limitPrice,min,setLimitOrderPriceError])
 
-    // const [price, setPrice] = useState(0);
 
     return (
         <Card className="px-3">

--- a/src/components/confirmOrderComponents/LimitPriceSelect.js
+++ b/src/components/confirmOrderComponents/LimitPriceSelect.js
@@ -62,19 +62,5 @@ function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPr
         </Card>
     )
 }
-//  <Card>
-//             <Container>
-//                 <h5 style={{ marginTop: "10px" }}>Limit Price</h5>
-//                 <p><strong>Portfolio A </strong>- Available Balance: ${portfolioBalance}</p>
-//                 <Row style={{ display: "flex", alignItems: "center", justifyContent: "center", marginBottom: "10px" }}>
 
-//                     <h2 style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>${parseFloat(price).toFixed(2)}</h2>
-//                     <br></br><br></br><br></br>
-
-//                     </Row>
-//                     <input type="range" className="form-range" min={0} max={500} value={price} step={0.01}
-//                         onChange={sliderCall}
-//                     />
-//             </Container>
-//         </Card>
 export default LimitPriceSelect;

--- a/src/components/confirmOrderComponents/LimitPriceSelect.js
+++ b/src/components/confirmOrderComponents/LimitPriceSelect.js
@@ -1,8 +1,9 @@
 import { Card } from "react-bootstrap";
 import { useState, useEffect } from 'react';
 import RangeSlider from "../widgets/RangeSlider/RangeSlider";
+import MessageAlert from "../widgets/MessageAlert/MessageAlert";
 
-function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPrice, setNewPortfolioBalance, limitPrice, buyOrSell,stockPrice }) {
+function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPrice, setNewPortfolioBalance, limitPrice, buyOrSell,stockPrice, limitOrderPriceError, setLimitOrderPriceError }) {
     const [min, setMin] = useState()
     const [max, setMax] = useState()
 
@@ -17,7 +18,17 @@ function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPr
             setMin(stockPrice+1)
             setMax(stockPrice*1.15)
         }
-    },[buyOrSell,setMin,setMax,stockPrice])
+        /// Check for errors 
+        if (limitPrice > max){
+            setLimitOrderPriceError(`Price over ${parseFloat(max).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}, try market buy if you want this price!`)
+        }else if(limitPrice < min){
+            setLimitOrderPriceError(`Price must be at least ${parseFloat(min).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}, try moving the slider to the right!`)
+        }else{
+            setLimitOrderPriceError("")
+        }
+
+
+    },[buyOrSell,setMin,setMax,stockPrice,max,limitPrice,min,setLimitOrderPriceError])
 
     // const [price, setPrice] = useState(0);
 
@@ -33,6 +44,7 @@ function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPr
             <h5 style={{ marginTop: "10px"}}>Price</h5>
                 <p>{`The price at which you wish to ${buyOrSell} stocks`}</p>
                 <Card.Body style={{"textAlign":"center","alignItems":"center"}}>
+                    {limitOrderPriceError && <MessageAlert variant="danger">{limitOrderPriceError}</MessageAlert>}
                      <RangeSlider 
                         setter={setLimitPrice}
                         state={limitPrice}
@@ -40,7 +52,7 @@ function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPr
                         min={min}
                         max={max}
                         startWidth={"2rem"}
-                        showError={true}
+                        showError={false}
                         reset={buyOrSell}
                         resetValue={"1"}
                     />

--- a/src/components/confirmOrderComponents/LimitPriceSelect.js
+++ b/src/components/confirmOrderComponents/LimitPriceSelect.js
@@ -1,33 +1,50 @@
-import { Card, Container, Row } from "react-bootstrap";
+import { Card } from "react-bootstrap";
 import { useState } from 'react';
+import RangeSlider from "../widgets/RangeSlider/RangeSlider";
 
-function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPrice, setNewPortfolioBalance }) {
-    const [price, setPrice] = useState(0);
+function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPrice, setNewPortfolioBalance, limitPrice, buyOrSell }) {
+    // const [price, setPrice] = useState(0);
 
-    const sliderCall = (e) => {
-        setPrice(e.target.value)
-        setLimitPrice(e.target.value)
-        setAmountSelected(e.target.value * qty)
-        setNewPortfolioBalance(portfolioBalance - (e.target.value * qty))
-    }
+    // const sliderCall = (e) => {
+    //     setPrice(e.target.value)
+    //     setLimitPrice(e.target.value)
+    //     setAmountSelected(e.target.value * qty)
+    //     setNewPortfolioBalance(portfolioBalance - (e.target.value * qty))
+    // }
 
     return (
-        <Card>
-            <Container>
-                <h5 style={{ marginTop: "10px" }}>Limit Price</h5>
-                <p><strong>Portfolio A </strong>- Available Balance: ${portfolioBalance}</p>
-                <Row style={{ display: "flex", alignItems: "center", justifyContent: "center", marginBottom: "10px" }}>
-
-                    <h2 style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>${parseFloat(price).toFixed(2)}</h2>
-                    <br></br><br></br><br></br>
-
-                    </Row>
-                    <input type="range" className="form-range" min={0} max={500} value={price} step={0.01}
-                        onChange={sliderCall}
+        <Card className="px-3">
+            <h5 style={{ marginTop: "10px"}}>Price</h5>
+                <p>{`The price at which you wish to ${buyOrSell} stocks`}</p>
+                <Card.Body style={{"textAlign":"center","alignItems":"center"}}>
+                     <RangeSlider 
+                        setter={setLimitPrice}
+                        state={limitPrice}
+                        label={"$"}
+                        min={1}
+                        max={10}
+                        startWidth={"2rem"}
+                        showError={true}
+                        reset={buyOrSell}
+                        resetValue={"1"}
                     />
-            </Container>
+                </Card.Body>
         </Card>
     )
 }
+//  <Card>
+//             <Container>
+//                 <h5 style={{ marginTop: "10px" }}>Limit Price</h5>
+//                 <p><strong>Portfolio A </strong>- Available Balance: ${portfolioBalance}</p>
+//                 <Row style={{ display: "flex", alignItems: "center", justifyContent: "center", marginBottom: "10px" }}>
 
+//                     <h2 style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>${parseFloat(price).toFixed(2)}</h2>
+//                     <br></br><br></br><br></br>
+
+//                     </Row>
+//                     <input type="range" className="form-range" min={0} max={500} value={price} step={0.01}
+//                         onChange={sliderCall}
+//                     />
+//             </Container>
+//         </Card>
 export default LimitPriceSelect;

--- a/src/components/confirmOrderComponents/LimitPriceSelect.js
+++ b/src/components/confirmOrderComponents/LimitPriceSelect.js
@@ -1,8 +1,24 @@
 import { Card } from "react-bootstrap";
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import RangeSlider from "../widgets/RangeSlider/RangeSlider";
 
-function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPrice, setNewPortfolioBalance, limitPrice, buyOrSell }) {
+function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPrice, setNewPortfolioBalance, limitPrice, buyOrSell,stockPrice }) {
+    const [min, setMin] = useState()
+    const [max, setMax] = useState()
+
+    useEffect(() => {
+        //// Set the max and min values 
+        if (buyOrSell === "Buy"){
+            // Set the min you ca set price to 1 dollar 
+            setMin(1)
+            // Max is dollar off the current stock price  
+            setMax(stockPrice-1)
+        }else if (buyOrSell === "Sell"){
+            setMin(stockPrice+1)
+            setMax(stockPrice*1.15)
+        }
+    },[buyOrSell,setMin,setMax,stockPrice])
+
     // const [price, setPrice] = useState(0);
 
     // const sliderCall = (e) => {
@@ -21,8 +37,8 @@ function LimitPriceSelect({ portfolioBalance, setAmountSelected, qty, setLimitPr
                         setter={setLimitPrice}
                         state={limitPrice}
                         label={"$"}
-                        min={1}
-                        max={10}
+                        min={min}
+                        max={max}
                         startWidth={"2rem"}
                         showError={true}
                         reset={buyOrSell}

--- a/src/components/confirmOrderComponents/LimitQuantitySelect.js
+++ b/src/components/confirmOrderComponents/LimitQuantitySelect.js
@@ -25,8 +25,6 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNew
             // Max you can select is determined by protfolio balance 
             // Round down so you dont get 20 decimal places  
             setMax(Math.floor((portfolioBalance-gameTradeFee)/limitPrice))
-            console.log("Max",max)
-            console.log("QTY",qty)
         }else if (buyOrSell === "Sell"){
             setMin(1)
             setMax(holding*stockPrice)
@@ -44,7 +42,7 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNew
                 console.log("Sell")
             }
         }else{
-            setError(`Cannot afford ${qty} stocks at ${parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} a share. Try lowering the price.`)
+            setError(`Cannot afford ${qty} stocks at ${parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} a share. Try lowering the price or the number of stocks.`)
         }
     },[buyOrSell,gameTradeFee,holding,max,min,portfolioBalance,qty,setNewPortfolioBalance,stockPrice,limitPrice])
 

--- a/src/components/confirmOrderComponents/LimitQuantitySelect.js
+++ b/src/components/confirmOrderComponents/LimitQuantitySelect.js
@@ -3,7 +3,8 @@ import { useState, useEffect } from 'react';
 import RangeSlider from "../widgets/RangeSlider/RangeSlider";
 import MessageAlert from "../widgets/MessageAlert/MessageAlert";
 
-function LimitQuantitySelect({setQty, qty, limitPrice, setDollarAmountSelected, setNewPortfolioBalance, portfolioBalance, buyOrSell, stockPrice, holding, gameTradeFee, limitOrderError, setLimitOrderError }) {
+function LimitQuantitySelect({setQty, qty, limitPrice, setDollarAmountSelected, setNewPortfolioBalance, portfolioBalance, buyOrSell, stockPrice, holding, gameTradeFee, 
+    limitOrderQuantityError, setLimitOrderQuantityError }) {
     // const [quantity, setQuantity] = useState(0);
 
     const [min, setMin] = useState()
@@ -30,7 +31,7 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setDollarAmountSelected, 
         }
         //// Only if the qty is within the max and min limit
         if (qty >= min && qty <= max){
-            setLimitOrderError("")
+            setLimitOrderQuantityError("")
             if(buyOrSell === "Buy"){
                 /// For Buy the new the current balance minus the currentStock Price*Qty slected minus the trade fee
                 setNewPortfolioBalance((portfolioBalance - ((qty*limitPrice) + gameTradeFee)))
@@ -42,17 +43,19 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setDollarAmountSelected, 
                 //setNewPortfolioBalance((parseFloat(portfolioBalance) + parseFloat(dollarAmountSelected) - parseFloat(gameTradeFee)))
                 console.log("Sell")
             }
-        }else{
-            setLimitOrderError(`Cannot afford ${qty} stocks at ${parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} a share. Try lowering the price or the number of stocks.`)
+        }else if (qty > max){
+            setLimitOrderQuantityError(`Cannot afford ${qty} stocks at ${parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} a share, try lowering the price or the number of stocks!`)
+        }else if (qty < min) {
+            setLimitOrderQuantityError(`Number of stocks must be at least ${min}, try moving the slider to the right!`)
         }
-    },[buyOrSell,gameTradeFee,holding,max,min,portfolioBalance,qty,setNewPortfolioBalance,stockPrice,limitPrice])
+    },[buyOrSell,gameTradeFee,holding,max,min,portfolioBalance,qty,setNewPortfolioBalance,stockPrice,limitPrice,setDollarAmountSelected, setLimitOrderQuantityError])
 
     return (
          <Card className="px-3">
                 <h5 style={{ marginTop: "10px"}}>Stocks</h5>
                 <p>{`The number of stocks you wish to ${buyOrSell}`}</p>
                 <Card.Body style={{"textAlign":"center","alignItems":"center"}}>
-                    {limitOrderError && <MessageAlert variant="danger">{limitOrderError}</MessageAlert>}
+                    {limitOrderQuantityError && <MessageAlert variant="danger">{limitOrderQuantityError}</MessageAlert>}
                      <RangeSlider 
                         setter={setQty}
                         state={qty}

--- a/src/components/confirmOrderComponents/LimitQuantitySelect.js
+++ b/src/components/confirmOrderComponents/LimitQuantitySelect.js
@@ -74,16 +74,4 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setDollarAmountSelected, 
             </Card>
     )
 }
-//   <Card>
-//             <Container>
-//                 <h5 style={{ marginTop: "10px" }}>Quantity</h5>
-//                 <Row style={{ display: "flex", alignItems: "center", justifyContent: "center", marginBottom: "10px" }}>
-//                     <h2 style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>{parseFloat(quantity).toFixed(2)} stocks</h2>
-//                     <br></br><br></br><br></br>
-//                     </Row>
-//                     <input type="range" className="form-range" min={0} max={10} value={quantity} step={0.01}
-//                         onChange={sliderCall}
-//                     />
-//             </Container>
-//         </Card>
 export default LimitQuantitySelect;

--- a/src/components/confirmOrderComponents/LimitQuantitySelect.js
+++ b/src/components/confirmOrderComponents/LimitQuantitySelect.js
@@ -44,7 +44,8 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setDollarAmountSelected, 
             }
         }else if (qty > max){
             /// Greeater than errors -> For buy they cant afford it, for sell they havent got that many 
-            if (buyOrSell === "Buy"){
+            /// Greater than 0 test here as the 0 test case is caught in portfolio balance component 
+            if (buyOrSell === "Buy" && (portfolioBalance-gameTradeFee > 0)){
                 setLimitOrderQuantityError(`Cannot afford ${qty} stocks at ${parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} a share, try lowering the price or the number of stocks!`)
             }else if (buyOrSell === "Sell"){
                 setLimitOrderQuantityError(`You cant sell what you dont have, you own ${holding.toFixed(2)} stocks`)

--- a/src/components/confirmOrderComponents/LimitQuantitySelect.js
+++ b/src/components/confirmOrderComponents/LimitQuantitySelect.js
@@ -32,12 +32,12 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setDollarAmountSelected, 
         //// Only if the qty is within the max and min limit
         if (qty >= min && qty <= max){
             setLimitOrderQuantityError("")
-            if(buyOrSell === "Buy"){
+            if(buyOrSell === "Buy" && (limitPrice>=1 && limitPrice <= stockPrice-1)){
                 /// For Buy the new the current balance minus the currentStock Price*Qty slected minus the trade fee
                 setNewPortfolioBalance((portfolioBalance - ((qty*limitPrice) + gameTradeFee)))
                 /// The amount slected will be the price times the quantity 
                 setDollarAmountSelected(qty*limitPrice)
-            }else if(buyOrSell === "Sell"){
+            }else if(buyOrSell === "Sell" && (limitPrice>=1 && limitPrice <= Math.floor(stockPrice*1.15))){
                 /// For sell the new portfolio balance will be the current portfolio balance + dollarAmount Select - game fee
                 setDollarAmountSelected(qty*limitPrice)
                 setNewPortfolioBalance((parseFloat(portfolioBalance) + parseFloat(qty*limitPrice) - parseFloat(gameTradeFee)))

--- a/src/components/confirmOrderComponents/LimitQuantitySelect.js
+++ b/src/components/confirmOrderComponents/LimitQuantitySelect.js
@@ -31,7 +31,7 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNew
         if (qty >= min && qty <= max){
             if(buyOrSell === "Buy"){
                 /// For Buy the new the current balance minus the currentStock Price*Qty slected minus the trade fee
-                setNewPortfolioBalance((portfolioBalance - ((qty*stockPrice) + gameTradeFee)))
+                setNewPortfolioBalance((portfolioBalance - ((qty*limitPrice) + gameTradeFee)))
             }else if(buyOrSell === "Sell"){
                 /// For sell the new portfolio balance will be the current portfolio balance + dollarAmount Select - game fee
                 //setQty(dollarAmountSelected / stockPrice)
@@ -39,7 +39,7 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNew
                 console.log("Sell")
             }
         }
-    },[buyOrSell,gameTradeFee,holding,max,min,portfolioBalance,qty,setNewPortfolioBalance,stockPrice])
+    },[buyOrSell,gameTradeFee,holding,max,min,portfolioBalance,qty,setNewPortfolioBalance,stockPrice,limitPrice])
 
     return (
          <Card className="px-3">

--- a/src/components/confirmOrderComponents/LimitQuantitySelect.js
+++ b/src/components/confirmOrderComponents/LimitQuantitySelect.js
@@ -3,12 +3,11 @@ import { useState, useEffect } from 'react';
 import RangeSlider from "../widgets/RangeSlider/RangeSlider";
 import MessageAlert from "../widgets/MessageAlert/MessageAlert";
 
-function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNewPortfolioBalance, portfolioBalance, buyOrSell, stockPrice, holding, gameTradeFee }) {
+function LimitQuantitySelect({setQty, qty, limitPrice, setDollarAmountSelected, setNewPortfolioBalance, portfolioBalance, buyOrSell, stockPrice, holding, gameTradeFee, limitOrderError, setLimitOrderError }) {
     // const [quantity, setQuantity] = useState(0);
 
     const [min, setMin] = useState()
     const [max, setMax] = useState()
-    const [error, setError] = useState("")
 
     // const sliderCall = (e) => {
     //     setQuantity(e.target.value)
@@ -31,10 +30,12 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNew
         }
         //// Only if the qty is within the max and min limit
         if (qty >= min && qty <= max){
-            setError("")
+            setLimitOrderError("")
             if(buyOrSell === "Buy"){
                 /// For Buy the new the current balance minus the currentStock Price*Qty slected minus the trade fee
                 setNewPortfolioBalance((portfolioBalance - ((qty*limitPrice) + gameTradeFee)))
+                /// The amount slected will be the price times the quantity 
+                setDollarAmountSelected(qty*limitPrice)
             }else if(buyOrSell === "Sell"){
                 /// For sell the new portfolio balance will be the current portfolio balance + dollarAmount Select - game fee
                 //setQty(dollarAmountSelected / stockPrice)
@@ -42,7 +43,7 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNew
                 console.log("Sell")
             }
         }else{
-            setError(`Cannot afford ${qty} stocks at ${parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} a share. Try lowering the price or the number of stocks.`)
+            setLimitOrderError(`Cannot afford ${qty} stocks at ${parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} a share. Try lowering the price or the number of stocks.`)
         }
     },[buyOrSell,gameTradeFee,holding,max,min,portfolioBalance,qty,setNewPortfolioBalance,stockPrice,limitPrice])
 
@@ -51,7 +52,7 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNew
                 <h5 style={{ marginTop: "10px"}}>Stocks</h5>
                 <p>{`The number of stocks you wish to ${buyOrSell}`}</p>
                 <Card.Body style={{"textAlign":"center","alignItems":"center"}}>
-                    {error && <MessageAlert variant="danger">{error}</MessageAlert>}
+                    {limitOrderError && <MessageAlert variant="danger">{limitOrderError}</MessageAlert>}
                      <RangeSlider 
                         setter={setQty}
                         state={qty}

--- a/src/components/confirmOrderComponents/LimitQuantitySelect.js
+++ b/src/components/confirmOrderComponents/LimitQuantitySelect.js
@@ -3,17 +3,17 @@ import { useState, useEffect } from 'react';
 import RangeSlider from "../widgets/RangeSlider/RangeSlider";
 
 function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNewPortfolioBalance, portfolioBalance, buyOrSell, stockPrice, holding, gameTradeFee }) {
-    const [quantity, setQuantity] = useState(0);
+    // const [quantity, setQuantity] = useState(0);
 
     const [min, setMin] = useState()
     const [max, setMax] = useState()
 
-    const sliderCall = (e) => {
-        setQuantity(e.target.value)
-        setQty(e.target.value)
-        setAmountSelected(e.target.value * limitPrice)
-        setNewPortfolioBalance(portfolioBalance - (e.target.value * limitPrice))
-    }
+    // const sliderCall = (e) => {
+    //     setQuantity(e.target.value)
+    //     setQty(e.target.value)
+    //     setAmountSelected(e.target.value * limitPrice)
+    //     setNewPortfolioBalance(portfolioBalance - (e.target.value * limitPrice))
+    // }
 
      useEffect(() => {
         //// Set the max and min values 
@@ -27,7 +27,19 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNew
             setMin(1)
             setMax(holding*stockPrice)
         }
-    },[])
+        //// Only if the qty is within the max and min limit
+        if (qty >= min && qty <= max){
+            if(buyOrSell === "Buy"){
+                /// For Buy the new the current balance minus the currentStock Price*Qty slected minus the trade fee
+                setNewPortfolioBalance((portfolioBalance - ((qty*stockPrice) + gameTradeFee)))
+            }else if(buyOrSell === "Sell"){
+                /// For sell the new portfolio balance will be the current portfolio balance + dollarAmount Select - game fee
+                //setQty(dollarAmountSelected / stockPrice)
+                //setNewPortfolioBalance((parseFloat(portfolioBalance) + parseFloat(dollarAmountSelected) - parseFloat(gameTradeFee)))
+                console.log("Sell")
+            }
+        }
+    },[buyOrSell,gameTradeFee,holding,max,min,portfolioBalance,qty,setNewPortfolioBalance,stockPrice])
 
     return (
          <Card className="px-3">

--- a/src/components/confirmOrderComponents/LimitQuantitySelect.js
+++ b/src/components/confirmOrderComponents/LimitQuantitySelect.js
@@ -27,7 +27,7 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setDollarAmountSelected, 
             setMax(Math.floor((portfolioBalance-gameTradeFee)/limitPrice))
         }else if (buyOrSell === "Sell"){
             setMin(1)
-            setMax(holding*stockPrice)
+            setMax(parseFloat((holding).toFixed(2)))
         }
         //// Only if the qty is within the max and min limit
         if (qty >= min && qty <= max){
@@ -39,12 +39,16 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setDollarAmountSelected, 
                 setDollarAmountSelected(qty*limitPrice)
             }else if(buyOrSell === "Sell"){
                 /// For sell the new portfolio balance will be the current portfolio balance + dollarAmount Select - game fee
-                //setQty(dollarAmountSelected / stockPrice)
-                //setNewPortfolioBalance((parseFloat(portfolioBalance) + parseFloat(dollarAmountSelected) - parseFloat(gameTradeFee)))
-                console.log("Sell")
+                setDollarAmountSelected(qty*limitPrice)
+                setNewPortfolioBalance((parseFloat(portfolioBalance) + parseFloat(qty*limitPrice) - parseFloat(gameTradeFee)))
             }
         }else if (qty > max){
-            setLimitOrderQuantityError(`Cannot afford ${qty} stocks at ${parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} a share, try lowering the price or the number of stocks!`)
+            /// Greeater than errors -> For buy they cant afford it, for sell they havent got that many 
+            if (buyOrSell === "Buy"){
+                setLimitOrderQuantityError(`Cannot afford ${qty} stocks at ${parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} a share, try lowering the price or the number of stocks!`)
+            }else if (buyOrSell === "Sell"){
+                setLimitOrderQuantityError(`You cant sell what you dont have, you own ${holding.toFixed(2)} stocks`)
+            }
         }else if (qty < min) {
             setLimitOrderQuantityError(`Number of stocks must be at least ${min}, try moving the slider to the right!`)
         }

--- a/src/components/confirmOrderComponents/LimitQuantitySelect.js
+++ b/src/components/confirmOrderComponents/LimitQuantitySelect.js
@@ -1,9 +1,12 @@
-import { Card, Container, Row } from "react-bootstrap";
-import { useState } from 'react';
+import { Card } from "react-bootstrap";
+import { useState, useEffect } from 'react';
 import RangeSlider from "../widgets/RangeSlider/RangeSlider";
 
-function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNewPortfolioBalance, portfolioBalance, buyOrSell }) {
+function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNewPortfolioBalance, portfolioBalance, buyOrSell, stockPrice, holding, gameTradeFee }) {
     const [quantity, setQuantity] = useState(0);
+
+    const [min, setMin] = useState()
+    const [max, setMax] = useState()
 
     const sliderCall = (e) => {
         setQuantity(e.target.value)
@@ -12,23 +15,30 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNew
         setNewPortfolioBalance(portfolioBalance - (e.target.value * limitPrice))
     }
 
-    
+     useEffect(() => {
+        //// Set the max and min values 
+        if (buyOrSell === "Buy"){
+            // Set the min you must buy to 1 share 
+            setMin(1)
+            // Max you can select is determined by protfolio balance 
+            // Round down so you dont get 20 decimal places  
+            setMax(Math.floor((portfolioBalance-gameTradeFee)/stockPrice))
+        }else if (buyOrSell === "Sell"){
+            setMin(1)
+            setMax(holding*stockPrice)
+        }
+    },[])
 
-
-
-
-    console.log(qty)
     return (
          <Card className="px-3">
-                <h5 style={{ marginTop: "10px"}}>Quantity </h5>
+                <h5 style={{ marginTop: "10px"}}>Quantity</h5>
+                <p>{`The number of stocks you wish to ${buyOrSell}`}</p>
                 <Card.Body style={{"textAlign":"center","alignItems":"center"}}>
-                    <h2>{parseFloat(qty).toFixed(2)} stocks</h2>
                      <RangeSlider 
-                        label={"$"}
                         setter={setQty}
                         state={qty}
-                        min={0}
-                        max={10}
+                        min={min}
+                        max={max}
                         startWidth={"2rem"}
                         showError={true}
                         reset={buyOrSell}

--- a/src/components/confirmOrderComponents/LimitQuantitySelect.js
+++ b/src/components/confirmOrderComponents/LimitQuantitySelect.js
@@ -1,7 +1,8 @@
 import { Card, Container, Row } from "react-bootstrap";
 import { useState } from 'react';
+import RangeSlider from "../widgets/RangeSlider/RangeSlider";
 
-function LimitQuantitySelect({ setQty, limitPrice, setAmountSelected, setNewPortfolioBalance, portfolioBalance }) {
+function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNewPortfolioBalance, portfolioBalance, buyOrSell }) {
     const [quantity, setQuantity] = useState(0);
 
     const sliderCall = (e) => {
@@ -11,22 +12,42 @@ function LimitQuantitySelect({ setQty, limitPrice, setAmountSelected, setNewPort
         setNewPortfolioBalance(portfolioBalance - (e.target.value * limitPrice))
     }
 
+    
+
+
+
+
+    console.log(qty)
     return (
-        <Card>
-            <Container>
-                <h5 style={{ marginTop: "10px" }}>Quantity</h5>
-                <Row style={{ display: "flex", alignItems: "center", justifyContent: "center", marginBottom: "10px" }}>
-
-                    <h2 style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>{parseFloat(quantity).toFixed(2)} stocks</h2>
-                    <br></br><br></br><br></br>
-
-                    </Row>
-                    <input type="range" className="form-range" min={0} max={10} value={quantity} step={0.01}
-                        onChange={sliderCall}
+         <Card className="px-3">
+                <h5 style={{ marginTop: "10px"}}>Quantity </h5>
+                <Card.Body style={{"textAlign":"center","alignItems":"center"}}>
+                    <h2>{parseFloat(qty).toFixed(2)} stocks</h2>
+                     <RangeSlider 
+                        label={"$"}
+                        setter={setQty}
+                        state={qty}
+                        min={0}
+                        max={10}
+                        startWidth={"2rem"}
+                        showError={true}
+                        reset={buyOrSell}
+                        resetValue={"1"}
                     />
-            </Container>
-        </Card>
+                </Card.Body>
+            </Card>
     )
 }
-
+//   <Card>
+//             <Container>
+//                 <h5 style={{ marginTop: "10px" }}>Quantity</h5>
+//                 <Row style={{ display: "flex", alignItems: "center", justifyContent: "center", marginBottom: "10px" }}>
+//                     <h2 style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>{parseFloat(quantity).toFixed(2)} stocks</h2>
+//                     <br></br><br></br><br></br>
+//                     </Row>
+//                     <input type="range" className="form-range" min={0} max={10} value={quantity} step={0.01}
+//                         onChange={sliderCall}
+//                     />
+//             </Container>
+//         </Card>
 export default LimitQuantitySelect;

--- a/src/components/confirmOrderComponents/LimitQuantitySelect.js
+++ b/src/components/confirmOrderComponents/LimitQuantitySelect.js
@@ -1,12 +1,14 @@
 import { Card } from "react-bootstrap";
 import { useState, useEffect } from 'react';
 import RangeSlider from "../widgets/RangeSlider/RangeSlider";
+import MessageAlert from "../widgets/MessageAlert/MessageAlert";
 
 function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNewPortfolioBalance, portfolioBalance, buyOrSell, stockPrice, holding, gameTradeFee }) {
     // const [quantity, setQuantity] = useState(0);
 
     const [min, setMin] = useState()
     const [max, setMax] = useState()
+    const [error, setError] = useState("")
 
     // const sliderCall = (e) => {
     //     setQuantity(e.target.value)
@@ -22,13 +24,16 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNew
             setMin(1)
             // Max you can select is determined by protfolio balance 
             // Round down so you dont get 20 decimal places  
-            setMax(Math.floor((portfolioBalance-gameTradeFee)/stockPrice))
+            setMax(Math.floor((portfolioBalance-gameTradeFee)/limitPrice))
+            console.log("Max",max)
+            console.log("QTY",qty)
         }else if (buyOrSell === "Sell"){
             setMin(1)
             setMax(holding*stockPrice)
         }
         //// Only if the qty is within the max and min limit
         if (qty >= min && qty <= max){
+            setError("")
             if(buyOrSell === "Buy"){
                 /// For Buy the new the current balance minus the currentStock Price*Qty slected minus the trade fee
                 setNewPortfolioBalance((portfolioBalance - ((qty*limitPrice) + gameTradeFee)))
@@ -38,21 +43,24 @@ function LimitQuantitySelect({setQty, qty, limitPrice, setAmountSelected, setNew
                 //setNewPortfolioBalance((parseFloat(portfolioBalance) + parseFloat(dollarAmountSelected) - parseFloat(gameTradeFee)))
                 console.log("Sell")
             }
+        }else{
+            setError(`Cannot afford ${qty} stocks at ${parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} a share. Try lowering the price.`)
         }
     },[buyOrSell,gameTradeFee,holding,max,min,portfolioBalance,qty,setNewPortfolioBalance,stockPrice,limitPrice])
 
     return (
          <Card className="px-3">
-                <h5 style={{ marginTop: "10px"}}>Quantity</h5>
+                <h5 style={{ marginTop: "10px"}}>Stocks</h5>
                 <p>{`The number of stocks you wish to ${buyOrSell}`}</p>
                 <Card.Body style={{"textAlign":"center","alignItems":"center"}}>
+                    {error && <MessageAlert variant="danger">{error}</MessageAlert>}
                      <RangeSlider 
                         setter={setQty}
                         state={qty}
                         min={min}
                         max={max}
                         startWidth={"2rem"}
-                        showError={true}
+                        showError={false}
                         reset={buyOrSell}
                         resetValue={"1"}
                     />

--- a/src/components/confirmOrderComponents/OrderSummary.js
+++ b/src/components/confirmOrderComponents/OrderSummary.js
@@ -52,11 +52,17 @@ function OrderSummary({ stockName, buyOrSell, orderType, dollarAmountSelected, n
                             } 
                             </>
                         }
-                            
-                            <tr style={{"borderTopWidth":"2px","borderTopColor":"grey"}}>
+                        {buyOrSell === "Sell" && orderType === "Limit Order"?
+                        <tr style={{"borderTopWidth":"2px","borderTopColor":"grey"}}>
+                                <td className="bolded">Potential New Spending Power</td>
+                                <td className="bolded">{parseFloat(newPortfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</td>
+                        </tr>
+                        :<tr style={{"borderTopWidth":"2px","borderTopColor":"grey"}}>
                                 <td className="bolded">New Spending Power</td>
                                 <td className="bolded">{parseFloat(newPortfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</td>
-                            </tr>
+                        </tr>
+                        } 
+                            
 
 
 

--- a/src/components/confirmOrderComponents/QuantitySelect.js
+++ b/src/components/confirmOrderComponents/QuantitySelect.js
@@ -1,8 +1,9 @@
 import { Card} from 'react-bootstrap';
 import { useEffect, useState } from 'react';
 import RangeSlider from '../widgets/RangeSlider/RangeSlider';
+import MessageAlert from '../widgets/MessageAlert/MessageAlert';
 
-function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSell, gameTradeFee, holding, setQty,  qty, portfolioBalance,  stockPrice,  setNewPortfolioBalance }) {
+function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSell, gameTradeFee, holding, setQty,  qty, portfolioBalance,  stockPrice,  setNewPortfolioBalance, marketPriceError, setMarketPriceError }) {
     const [min, setMin] = useState()
     const [max, setMax] = useState()
     
@@ -18,6 +19,7 @@ function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSe
 
         //// Only Update the states if within max and min limits 
         if (dollarAmountSelected >= 1 &&  dollarAmountSelected <= max){
+            setMarketPriceError("")
             /// Calculating the new portfolio balance will differ if its a buy or sell 
             if(buyOrSell === "Buy"){
                 /// Quantity is in units of stocks 
@@ -25,13 +27,24 @@ function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSe
                 /// For Buy the new balance will be the cost of the transaction minus the current balance 
                 setNewPortfolioBalance((portfolioBalance - dollarAmountSelected - gameTradeFee))
             }else if(buyOrSell === "Sell"){
-                console.log("I AM HIT ")
                 /// For sell the new portfolio balance will be the current portfolio balance + dollarAmount Select - game fee
                 setQty(dollarAmountSelected / stockPrice)
                 setNewPortfolioBalance((parseFloat(portfolioBalance) + parseFloat(dollarAmountSelected) - parseFloat(gameTradeFee)))
             }
+        }else if (dollarAmountSelected > max){
+            if (buyOrSell === "Buy"){
+                /// If we a re greater than max in a buy order then we are trying to spend more money than we have 
+                setMarketPriceError(` 
+                    ${parseFloat(dollarAmountSelected).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} 
+                    with ${parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} 
+                    trade fee is greater than spending power of ${parseFloat(portfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}`)
+            }else if (buyOrSell === "Sell"){
+                setMarketPriceError(`Max amount you own and is available to sell is ${parseFloat(holding*stockPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} worth`)
+            }
         }
-    },[dollarAmountSelected,buyOrSell,portfolioBalance,setNewPortfolioBalance,stockPrice,gameTradeFee,setQty,max,holding])
+
+
+    },[dollarAmountSelected,buyOrSell,portfolioBalance,setNewPortfolioBalance,stockPrice,gameTradeFee,setQty,max,holding,setMarketPriceError])
 
 
     return (
@@ -39,6 +52,7 @@ function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSe
                 <h5 style={{ marginTop: "10px"}}>Quantity </h5>
                 <p>{`Excludes ${parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} trade fee`}</p>
                 <Card.Body style={{"textAlign":"center","alignItems":"center"}}>
+                    {marketPriceError && <MessageAlert variant="danger">{marketPriceError}</MessageAlert>}
                     <h2>{parseFloat(qty).toFixed(2)} stocks</h2>
                      <RangeSlider 
                         label={"$"}
@@ -47,7 +61,7 @@ function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSe
                         min={min}
                         max={max}
                         startWidth={"2rem"}
-                        showError={true}
+                        showError={false}
                         reset={buyOrSell}
                         resetValue={"1"}
                     />

--- a/src/components/confirmOrderComponents/QuantitySelect.js
+++ b/src/components/confirmOrderComponents/QuantitySelect.js
@@ -17,6 +17,10 @@ function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSe
             setMax(holding*stockPrice)
         }
 
+        // if (portfolioBalance < gameTradeFee){
+        //     /// Portfolio balance is not enough to make a trade 
+        //     setMarketPriceError(`Your current spending power ${parseFloat(portfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} is less than the game trade fee of ${parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}, you dont have enough to make this trade!`)
+        // }
         //// Only Update the states if within max and min limits 
         if (dollarAmountSelected >= 1 &&  dollarAmountSelected <= max){
             setMarketPriceError("")

--- a/src/components/confirmOrderComponents/QuantitySelect.js
+++ b/src/components/confirmOrderComponents/QuantitySelect.js
@@ -34,13 +34,12 @@ function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSe
         }else if (dollarAmountSelected > max){
             if (buyOrSell === "Buy"){
                 /// If we a re greater than max in a buy order then we are trying to spend more money than we have 
-                setMarketPriceError(` 
-                    ${parseFloat(dollarAmountSelected).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} 
-                    with ${parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} 
-                    trade fee is greater than spending power of ${parseFloat(portfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}`)
+                setMarketPriceError(`Max quantity with your spending power is ${parseFloat(portfolioBalance -gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}, try reducing your quantity!`)
             }else if (buyOrSell === "Sell"){
                 setMarketPriceError(`Max amount you own and is available to sell is ${parseFloat(holding*stockPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} worth`)
             }
+        }else if (dollarAmountSelected < min){
+            setMarketPriceError(`Amount needs to be at least $1`)
         }
 
 

--- a/src/components/confirmOrderComponents/QuantitySelect.js
+++ b/src/components/confirmOrderComponents/QuantitySelect.js
@@ -34,16 +34,16 @@ function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSe
         }else if (dollarAmountSelected > max){
             if (buyOrSell === "Buy"){
                 /// If we a re greater than max in a buy order then we are trying to spend more money than we have 
-                setMarketPriceError(`Max quantity with your spending power is ${parseFloat(portfolioBalance -gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}, try reducing your quantity!`)
+                setMarketPriceError(`You can only spend ${parseFloat(portfolioBalance-gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} due to the ${parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} game trade fee`)
             }else if (buyOrSell === "Sell"){
-                setMarketPriceError(`Max amount you own and is available to sell is ${parseFloat(holding*stockPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} worth`)
+                setMarketPriceError(`You only own ${parseFloat(holding*stockPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} worth, try buying more to sell more first!`)
             }
         }else if (dollarAmountSelected < min){
-            setMarketPriceError(`Amount needs to be at least $1`)
+            setMarketPriceError(`Needs to be at least $1`)
         }
 
 
-    },[dollarAmountSelected,buyOrSell,portfolioBalance,setNewPortfolioBalance,stockPrice,gameTradeFee,setQty,max,holding,setMarketPriceError])
+    },[dollarAmountSelected,buyOrSell,portfolioBalance,setNewPortfolioBalance,stockPrice,gameTradeFee,setQty,max,holding,setMarketPriceError,min])
 
 
     return (

--- a/src/components/confirmOrderComponents/QuantitySelect.js
+++ b/src/components/confirmOrderComponents/QuantitySelect.js
@@ -25,6 +25,7 @@ function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSe
                 /// For Buy the new balance will be the cost of the transaction minus the current balance 
                 setNewPortfolioBalance((portfolioBalance - dollarAmountSelected - gameTradeFee))
             }else if(buyOrSell === "Sell"){
+                console.log("I AM HIT ")
                 /// For sell the new portfolio balance will be the current portfolio balance + dollarAmount Select - game fee
                 setQty(dollarAmountSelected / stockPrice)
                 setNewPortfolioBalance((parseFloat(portfolioBalance) + parseFloat(dollarAmountSelected) - parseFloat(gameTradeFee)))

--- a/src/components/confirmOrderComponents/QuantitySelect.js
+++ b/src/components/confirmOrderComponents/QuantitySelect.js
@@ -17,10 +17,7 @@ function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSe
             setMax(holding*stockPrice)
         }
 
-        // if (portfolioBalance < gameTradeFee){
-        //     /// Portfolio balance is not enough to make a trade 
-        //     setMarketPriceError(`Your current spending power ${parseFloat(portfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} is less than the game trade fee of ${parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}, you dont have enough to make this trade!`)
-        // }
+       
         //// Only Update the states if within max and min limits 
         if (dollarAmountSelected >= 1 &&  dollarAmountSelected <= max){
             setMarketPriceError("")
@@ -36,7 +33,8 @@ function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSe
                 setNewPortfolioBalance((parseFloat(portfolioBalance) + parseFloat(dollarAmountSelected) - parseFloat(gameTradeFee)))
             }
         }else if (dollarAmountSelected > max){
-            if (buyOrSell === "Buy"){
+            /// Greater than 0 test here as the 0 test case is caught in portfolio balance component 
+            if (buyOrSell === "Buy" && (portfolioBalance-gameTradeFee > 0)){
                 /// If we a re greater than max in a buy order then we are trying to spend more money than we have 
                 setMarketPriceError(`You can only spend ${parseFloat(portfolioBalance-gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} due to the ${parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} game trade fee`)
             }else if (buyOrSell === "Sell"){

--- a/src/components/confirmOrderComponents/QuantitySelect.js
+++ b/src/components/confirmOrderComponents/QuantitySelect.js
@@ -36,7 +36,7 @@ function QuantitySelect({ dollarAmountSelected, setDollarAmountSelected, buyOrSe
                 /// If we a re greater than max in a buy order then we are trying to spend more money than we have 
                 setMarketPriceError(`You can only spend ${parseFloat(portfolioBalance-gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} due to the ${parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} game trade fee`)
             }else if (buyOrSell === "Sell"){
-                setMarketPriceError(`You only own ${parseFloat(holding*stockPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} worth, try buying more to sell more first!`)
+                setMarketPriceError(`You only own ${parseFloat(holding*stockPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} worth, try lowering the quantity!`)
             }
         }else if (dollarAmountSelected < min){
             setMarketPriceError(`Needs to be at least $1`)

--- a/src/components/confirmOrderComponents/balanceComponent.js
+++ b/src/components/confirmOrderComponents/balanceComponent.js
@@ -61,7 +61,28 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
                     />
                     </h5>
                     :
-                    <h5 style={{ marginTop: "10px" }}>New Spending Power</h5>
+                    <h5 style={{ marginTop: "10px" }}>New Spending Power
+                    <InfoButtonModal
+                        title="New Spending Power" info={
+                        <>
+                        <p>Spending Power is the amount in Dollars you have available to purchase stocks.</p>
+                        { buyOrSell === "Buy" ?
+                        <> 
+                        <p>You have selected <span className="semibolded">Buy</span> which means you are purchasing stocks.</p>
+                        <p>This results in your Spending Power <span className="semibolded redNegative">Decreasing.</span></p>
+                        </>
+                        :
+                        <>
+                        <p>You have selected <span className="semibolded">Sell</span> which means you are selling stocks you previously bought.</p>
+                        <p>This results in your Spending Power <span className="bolded greenPositive">Increasing.</span></p>
+                        </>
+                        
+                        }
+                        
+                        </>
+                        }
+                    />
+                    </h5>
                     }
                     <p><strong>{portfolioName}</strong>- Available Spending Power: {parseFloat(portfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</p>
                     <ResponsiveContainer width="100%" height={300} margin={100}>

--- a/src/components/confirmOrderComponents/balanceComponent.js
+++ b/src/components/confirmOrderComponents/balanceComponent.js
@@ -27,9 +27,9 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
         if(buyOrSell === "Buy"){
                 setData([{ value: newPortfolioBalance },{ value: parseFloat(dollarAmountSelected) }]);
         }else if(buyOrSell === "Sell"){
-                if (orderType === "Market Order"){
-                   setData([{ value: parseFloat(portfolioBalance) },{ value: parseFloat(dollarAmountSelected) }, { value:(holding*stockPrice)-dollarAmountSelected}]) 
-                }else{
+                if (orderType === "Market Order" && (dollarAmountSelected <= (holding*stockPrice))){
+                    setData([{ value: parseFloat(portfolioBalance) },{ value: parseFloat(dollarAmountSelected) }, { value:(holding*stockPrice)-dollarAmountSelected}]) 
+                }else if (orderType === "Limit Order"){
                     setData([{ value: parseFloat(portfolioBalance) },{ value: parseFloat(dollarAmountSelected) }, { value:((Math.floor(stockPrice*1.15))*holding)-dollarAmountSelected}]) 
                 }
                 

--- a/src/components/confirmOrderComponents/balanceComponent.js
+++ b/src/components/confirmOrderComponents/balanceComponent.js
@@ -25,6 +25,7 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
     };
 
     useEffect(() => {
+        const setGraphData = () => {
         if(buyOrSell === "Buy"){
                 setData([{ value: newPortfolioBalance },{ value: parseFloat(dollarAmountSelected) }]);
         }else if(buyOrSell === "Sell"){
@@ -34,7 +35,9 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
                     setData([{ value: parseFloat(portfolioBalance) },{ value: parseFloat(dollarAmountSelected) }, { value:((Math.floor(stockPrice*1.15))*holding)-dollarAmountSelected}]) 
                 }
         }
-    }, [buyOrSell,dollarAmountSelected,newPortfolioBalance,stockPrice,holding,portfolioBalance, orderType])
+        }
+        setGraphData()
+    }, [setData,buyOrSell,dollarAmountSelected,newPortfolioBalance,stockPrice,holding,portfolioBalance, orderType])
 
     return (
         <>
@@ -53,8 +56,7 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
                         <p><span className="semibolded">{qty}</span> x <span className="semibolded"> {parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span> = <span className="semibolded">{parseFloat(limitPrice*qty).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} </span></p>
                         <p>Your Potential Spending Power is this number added onto your current Spending Power of <span className="semibolded"> {parseFloat(portfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span> minus the Game trade fee of <span className="semibolded">{parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span></p>
                         <p><span className="bolded">Potential New Spending Power:</span> </p><p><span className="semibolded">{parseFloat(portfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span> +  
-                            <span className="semibolded">{parseFloat(limitPrice*qty).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span> - <span className="semibolded">{parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span> =
-                            <span className="bolded">{parseFloat(((limitPrice*qty)+portfolioBalance)-gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} </span>
+                            <span className="semibolded">{parseFloat(limitPrice*qty).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span> - <span className="semibolded">{parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span> = <span className="bolded">{parseFloat(((limitPrice*qty)+portfolioBalance)-gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} </span>
                         </p>
                         </>
                         }

--- a/src/components/confirmOrderComponents/balanceComponent.js
+++ b/src/components/confirmOrderComponents/balanceComponent.js
@@ -4,7 +4,7 @@ import {useEffect,useState} from 'react';
 
 
 
-function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSelected, portfolioBalance, buyOrSell, stockPrice, holding }) {
+function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSelected, portfolioBalance, buyOrSell, stockPrice, holding, orderType}) {
     const [data, setData] = useState(true);
 
     const CustomLabel = ({ viewBox, balance = 0, text }) => {
@@ -27,9 +27,14 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
         if(buyOrSell === "Buy"){
                 setData([{ value: newPortfolioBalance },{ value: parseFloat(dollarAmountSelected) }]);
         }else if(buyOrSell === "Sell"){
-                setData([{ value: parseFloat(portfolioBalance) },{ value: parseFloat(dollarAmountSelected) }, { value:(holding*stockPrice)-dollarAmountSelected}])
+                if (orderType === "Market Order"){
+                   setData([{ value: parseFloat(portfolioBalance) },{ value: parseFloat(dollarAmountSelected) }, { value:(holding*stockPrice)-dollarAmountSelected}]) 
+                }else{
+                    setData([{ value: parseFloat(portfolioBalance) },{ value: parseFloat(dollarAmountSelected) }, { value:((Math.floor(stockPrice*1.15))*holding)-dollarAmountSelected}]) 
+                }
+                
         }
-    }, [buyOrSell,dollarAmountSelected,newPortfolioBalance,stockPrice,holding,portfolioBalance])
+    }, [buyOrSell,dollarAmountSelected,newPortfolioBalance,stockPrice,holding,portfolioBalance, orderType])
 
     return (
         <>

--- a/src/components/confirmOrderComponents/balanceComponent.js
+++ b/src/components/confirmOrderComponents/balanceComponent.js
@@ -2,10 +2,11 @@ import { Card, Container } from "react-bootstrap";
 import { Pie, PieChart, Cell, ResponsiveContainer, Label } from "recharts";
 import {useEffect,useState} from 'react';
 import InfoButtonModal from "../widgets/InfoButtonModal/InfoButtonModal";
+import MessageAlert from "../widgets/MessageAlert/MessageAlert";
 
 
 
-function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSelected, portfolioBalance, buyOrSell, stockPrice, holding, orderType, limitPrice, qty, gameTradeFee}) {
+function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSelected, portfolioBalance, buyOrSell, stockPrice, holding, orderType, limitPrice, qty, gameTradeFee, spendingPowerError, setSpendingPowerError}) {
     const [data, setData] = useState(true);
 
     const CustomLabel = ({ viewBox, balance = 0, text }) => {
@@ -26,7 +27,10 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
 
     useEffect(() => {
         const setGraphData = () => {
-        if(buyOrSell === "Buy"){
+        /// If your current spending power is greater than the game trade fee you cant complete the order
+        if (portfolioBalance < gameTradeFee){
+            setSpendingPowerError(`Available spending power of ${parseFloat(portfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} less than game trade fee of ${parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}, you dont have enough to make this trade!`)
+        }else if(buyOrSell === "Buy"){
                 setData([{ value: newPortfolioBalance },{ value: parseFloat(dollarAmountSelected) }]);
         }else if(buyOrSell === "Sell"){
                 if (orderType === "Market Order" && (dollarAmountSelected <= (holding*stockPrice))){
@@ -37,7 +41,7 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
         }
         }
         setGraphData()
-    }, [setData,buyOrSell,dollarAmountSelected,newPortfolioBalance,stockPrice,holding,portfolioBalance, orderType])
+    }, [setData,buyOrSell,dollarAmountSelected,newPortfolioBalance,stockPrice,holding,portfolioBalance, orderType, gameTradeFee, setSpendingPowerError])
 
     return (
         <>
@@ -87,6 +91,8 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
                     </h5>
                     }
                     <p><strong>{portfolioName}</strong>- Available Spending Power: {parseFloat(portfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</p>
+                    {spendingPowerError ? <MessageAlert variant="danger">{spendingPowerError}</MessageAlert>
+                    :
                     <ResponsiveContainer width="100%" height={300} margin={100}>
                         <PieChart height={260} width={500}>
                             <Pie
@@ -116,6 +122,8 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
                             </Pie>
                         </PieChart>
                     </ResponsiveContainer>
+                    }
+                    
 
                 </Container>
             </Card>

--- a/src/components/confirmOrderComponents/balanceComponent.js
+++ b/src/components/confirmOrderComponents/balanceComponent.js
@@ -1,10 +1,11 @@
 import { Card, Container } from "react-bootstrap";
 import { Pie, PieChart, Cell, ResponsiveContainer, Label } from "recharts";
 import {useEffect,useState} from 'react';
+import InfoButtonModal from "../widgets/InfoButtonModal/InfoButtonModal";
 
 
 
-function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSelected, portfolioBalance, buyOrSell, stockPrice, holding, orderType}) {
+function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSelected, portfolioBalance, buyOrSell, stockPrice, holding, orderType, limitPrice, qty, gameTradeFee}) {
     const [data, setData] = useState(true);
 
     const CustomLabel = ({ viewBox, balance = 0, text }) => {
@@ -39,7 +40,29 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
         <>
             <Card>
                 <Container>
+                    {buyOrSell === "Sell" && orderType === "Limit Order" ? 
+                    <h5 style={{ marginTop: "10px" }}>Potential New Spending Power
+                    <InfoButtonModal
+                        title="Potential New Spending Power" info={
+                        <>
+                        <p>The order you are placing is a <span className="semibolded">Limit Sell Order.</span></p>
+                        <p>The New Spending Power is not certain and hence marked as the <span className="semibolded">Potential Spending Power.</span></p>
+                        <p>The order will be completed in the future when the value of the stock reaches the limit price you inputted of <span className="semibolded"> {parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span>.</p>
+                        <p>At this point your spending power will rise by the number of stocks you are selling, in this case <span className="semibolded">{qty}</span> multipled by the limit price 
+                        <span className="semibolded"> {parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}.</span></p>
+                        <p><span className="semibolded">{qty}</span> x <span className="semibolded"> {parseFloat(limitPrice).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span> = <span className="semibolded">{parseFloat(limitPrice*qty).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} </span></p>
+                        <p>Your Potential Spending Power is this number added onto your current Spending Power of <span className="semibolded"> {parseFloat(portfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span> minus the Game trade fee of <span className="semibolded">{parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span></p>
+                        <p><span className="bolded">Potential New Spending Power:</span> </p><p><span className="semibolded">{parseFloat(portfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span> +  
+                            <span className="semibolded">{parseFloat(limitPrice*qty).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span> - <span className="semibolded">{parseFloat(gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</span> =
+                            <span className="bolded">{parseFloat(((limitPrice*qty)+portfolioBalance)-gameTradeFee).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} </span>
+                        </p>
+                        </>
+                        }
+                    />
+                    </h5>
+                    :
                     <h5 style={{ marginTop: "10px" }}>New Spending Power</h5>
+                    }
                     <p><strong>{portfolioName}</strong>- Available Spending Power: {parseFloat(portfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })}</p>
                     <ResponsiveContainer width="100%" height={300} margin={100}>
                         <PieChart height={260} width={500}>
@@ -62,7 +85,9 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
                                    </>
                                 }
                              <Label
-                                    content={<CustomLabel text={"Spending Power"} balance={parseFloat(newPortfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} />}
+                                    content={<CustomLabel 
+                                    text={"Spending Power"} 
+                                    balance={parseFloat(newPortfolioBalance).toLocaleString('en-US', {style: 'currency', currency: 'USD' })} />}
                                     position="center"
                                 />
                             </Pie>

--- a/src/components/confirmOrderComponents/balanceComponent.js
+++ b/src/components/confirmOrderComponents/balanceComponent.js
@@ -32,7 +32,6 @@ function BalanceComponent({ portfolioName, newPortfolioBalance, dollarAmountSele
                 }else if (orderType === "Limit Order"){
                     setData([{ value: parseFloat(portfolioBalance) },{ value: parseFloat(dollarAmountSelected) }, { value:((Math.floor(stockPrice*1.15))*holding)-dollarAmountSelected}]) 
                 }
-                
         }
     }, [buyOrSell,dollarAmountSelected,newPortfolioBalance,stockPrice,holding,portfolioBalance, orderType])
 

--- a/src/components/gameComponents/gameScreenComponents/createGameCard/createGameCard.js
+++ b/src/components/gameComponents/gameScreenComponents/createGameCard/createGameCard.js
@@ -16,7 +16,7 @@ function CreateGameCard(){
     return(
         <Link to={'/game/creategame'} style={{ textDecoration: 'none' }}>
            <Card className="createGameCard">
-            <Card.Img className="creatGameCardImage" src="create_game_image.jpg" alt="Card image" />
+            <Card.Img className="creatGameCardImage" src="/create_game_image.jpg" alt="Card image" />
             <Card.ImgOverlay >
             <Card.Body>
                 <Card.Title className="createGameCardHeading">Create a Game</Card.Title>

--- a/src/components/widgets/BottomStickyButton/BottomStickyButton.js
+++ b/src/components/widgets/BottomStickyButton/BottomStickyButton.js
@@ -1,11 +1,11 @@
 
 import { Card, Button } from 'react-bootstrap';
 
-function BottomyStickyButton({ text, onClick }) {
+function BottomyStickyButton({ text, onClick, disabled }) {
     return (
         <Card className="tradeButtonCard rounded-0" >
             <Card.Body>
-                <Button onClick = {onClick} variant="seconday" className="btn btn-secondary btn-lg">{text}</Button>
+                <Button onClick = {onClick} variant="seconday" className="btn btn-secondary btn-lg" disabled={disabled}>{text}</Button>
             </Card.Body>
         </Card>
 

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -259,6 +259,8 @@ function OrderConfirmationPage() {
                                     portfolioBalance={portfolio.portfolioBalance}
                                     setDollarAmountSelected={setDollarAmountSelected}
                                     qty={qty}
+                                    limitPrice={limitPrice}
+                                    buyOrSell={buyOrSell}
                                     setLimitPrice={setLimitPrice}
                                     setNewPortfolioBalance={setNewPortfolioBalance}
                                 />

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -39,6 +39,7 @@ function OrderConfirmationPage() {
     const [limitOrderPriceError, setLimitOrderPriceError] = useState("")
     const [marketPriceError, setMarketPriceError] = useState("")
     const [showAreYouSureModal, setShowAreYouSureModal ] = useState(false);
+    const [spendingPowerError, setSpendingPowerError] = useState("");
    
     /// Game State ///
     const [gameTradeFee, setGameTradeFee] = useState()
@@ -276,6 +277,9 @@ function OrderConfirmationPage() {
                                     limitPrice={limitPrice}
                                     qty={qty}
                                     gameTradeFee={gameTradeFee}
+                                    marketPriceError = {marketPriceError}
+                                    spendingPowerError= {spendingPowerError}
+                                    setSpendingPowerError={setSpendingPowerError}
                                 />
                             </Col>
                     <AreYouSure showState={showAreYouSureModal} setShowState={setShowAreYouSureModal} 
@@ -294,7 +298,7 @@ function OrderConfirmationPage() {
                         onClick={() =>{setShowAreYouSureModal(true)}} 
                         text="Review Trade!" 
                         disabled={
-                            (limitOrderQuantityError || limitOrderPriceError || marketPriceError)
+                            (limitOrderQuantityError || limitOrderPriceError || marketPriceError || spendingPowerError)
                         }></BottomStickyButton>
                     <div className='footerStyle'></div>
                 </Container>

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -35,6 +35,7 @@ function OrderConfirmationPage() {
     const [isShownMarketOrder, setIsShownMarketOrder] = useState(false)
     const [isShownLimitOrder, setIsShownLimitOrder] = useState(false)
     const [limitPrice, setLimitPrice] = useState(0)
+    const [limitOrderError, setLimitOrderError] = useState("")
     const [showAreYouSureModal, setShowAreYouSureModal ] = useState(false);
    
     /// Game State ///
@@ -263,6 +264,8 @@ function OrderConfirmationPage() {
                                     gameTradeFee={gameTradeFee}
                                     setDollarAmountSelected={setDollarAmountSelected}
                                     setNewPortfolioBalance={setNewPortfolioBalance}
+                                    limitOrderError={limitOrderError}
+                                    setLimitOrderError={setLimitOrderError}
                                 />
                             </Col>
                             
@@ -280,7 +283,15 @@ function OrderConfirmationPage() {
                             stockName={stock.longname}
                             gameTradeFee={gameTradeFee}
                 />
-                    <BottomStickyButton onClick={() =>{setShowAreYouSureModal(true)}} text="Review Trade!"></BottomStickyButton>
+                    <BottomStickyButton 
+                        onClick={() =>{setShowAreYouSureModal(true)}} 
+                        text="Review Trade!" 
+                        disabled={
+                            limitOrderError
+
+
+
+                        }></BottomStickyButton>
                     <div className='footerStyle'></div>
                 </Container>
             }

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -308,7 +308,7 @@ function OrderConfirmationPage() {
                         onClick={() =>{setShowAreYouSureModal(true)}} 
                         text="Review Trade!" 
                         disabled={
-                            (limitOrderQuantityError || limitOrderPriceError)
+                            (limitOrderQuantityError || limitOrderPriceError || marketPriceError)
                         }></BottomStickyButton>
                     <div className='footerStyle'></div>
                 </Container>

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -37,6 +37,7 @@ function OrderConfirmationPage() {
     const [limitPrice, setLimitPrice] = useState(0)
     const [limitOrderQuantityError, setLimitOrderQuantityError] = useState("")
     const [limitOrderPriceError, setLimitOrderPriceError] = useState("")
+    const [marketPriceError, setMarketPriceError] = useState("")
     const [showAreYouSureModal, setShowAreYouSureModal ] = useState(false);
    
     /// Game State ///
@@ -218,6 +219,8 @@ function OrderConfirmationPage() {
                                     maxQuantity={portfolio.portfolioBalance-gameTradeFee}
                                     qty={qty}
                                     holding={holding}
+                                    marketPriceError = {marketPriceError}
+                                    setMarketPriceError = {setMarketPriceError}
                                 />
                                 </Col>
                         </Row>

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -101,7 +101,8 @@ function OrderConfirmationPage() {
         setLimitOrderQuantityError("")
         setLimitOrderPriceError("")
         setMarketPriceError("")
-    }, [orderType])
+        setSpendingPowerError("")
+    }, [orderType,portfolioId])
 
 
     /// Portfolio Id 

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -161,6 +161,7 @@ function OrderConfirmationPage() {
         }
     },[buyOrSell])
 
+    console.log(newPortfolioBalance)
     return (
         <>
             { stockLoading || loading || portfolioLoading ? <LoadingSpinner /> 

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -231,6 +231,8 @@ function OrderConfirmationPage() {
                                     buyOrSell={buyOrSell}
                                     holding={holding}
                                     stockPrice={stock.daily_change.currentprice}
+                                    orderType={orderType}
+                                    limitPrice={limitPrice}
                                 />
                             </Col>
                         </Row>
@@ -269,7 +271,19 @@ function OrderConfirmationPage() {
                                     setLimitOrderQuantityError={setLimitOrderQuantityError}
                                 />
                             </Col>
-                            
+                            <Col style={{ marginBottom: "0.625rem" }}>
+                                <BalanceComponent
+                                    portfolioName={portfolio.portfolioName}
+                                    portfolioBalance={portfolio.portfolioBalance}
+                                    newPortfolioBalance={newPortfolioBalance}
+                                    dollarAmountSelected={dollarAmountSelected}
+                                    buyOrSell={buyOrSell}
+                                    holding={holding}
+                                    stockPrice={stock.daily_change.currentprice}
+                                    orderType={orderType}
+                                    limitPrice={limitPrice}
+                                />
+                            </Col>
                         </Row>
                     }
                     <AreYouSure showState={showAreYouSureModal} setShowState={setShowAreYouSureModal} 

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -236,6 +236,7 @@ function OrderConfirmationPage() {
                                     stockPrice={stock.daily_change.currentprice}
                                     orderType={orderType}
                                     limitPrice={limitPrice}
+                                    qty={qty}
                                 />
                             </Col>
                         </Row>
@@ -285,6 +286,8 @@ function OrderConfirmationPage() {
                                     stockPrice={stock.daily_change.currentprice}
                                     orderType={orderType}
                                     limitPrice={limitPrice}
+                                    qty={qty}
+                                    gameTradeFee={gameTradeFee}
                                 />
                             </Col>
                         </Row>

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -161,7 +161,6 @@ function OrderConfirmationPage() {
         }
     },[buyOrSell])
 
-    console.log(newPortfolioBalance)
     return (
         <>
             { stockLoading || loading || portfolioLoading ? <LoadingSpinner /> 

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -243,6 +243,8 @@ function OrderConfirmationPage() {
                                 <LimitQuantitySelect
                                     portfolioBalance={portfolio.portfolioBalance}
                                     setQty={setQty}
+                                    qty={qty}
+                                    buyOrSell={buyOrSell}
                                     limitPrice={limitPrice}
                                     setDollarAmountSelected={setDollarAmountSelected}
                                     setNewPortfolioBalance={setNewPortfolioBalance}

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -245,7 +245,10 @@ function OrderConfirmationPage() {
                                     setQty={setQty}
                                     qty={qty}
                                     buyOrSell={buyOrSell}
+                                    stockPrice={stock.daily_change.currentprice}
                                     limitPrice={limitPrice}
+                                    holding={holding}
+                                    gameTradeFee={gameTradeFee}
                                     setDollarAmountSelected={setDollarAmountSelected}
                                     setNewPortfolioBalance={setNewPortfolioBalance}
                                 />

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -241,6 +241,18 @@ function OrderConfirmationPage() {
                     {isShownLimitOrder &&
                         <Row className="my-2" sm={1} md={1} >
                             <Col style={{ marginBottom: "0.625rem" }}>
+                                <LimitPriceSelect
+                                    portfolioBalance={portfolio.portfolioBalance}
+                                    setDollarAmountSelected={setDollarAmountSelected}
+                                    qty={qty}
+                                    limitPrice={limitPrice}
+                                    buyOrSell={buyOrSell}
+                                    setLimitPrice={setLimitPrice}
+                                    stockPrice={stock.daily_change.currentprice}
+                                    setNewPortfolioBalance={setNewPortfolioBalance}
+                                />
+                            </Col>
+                            <Col style={{ marginBottom: "0.625rem" }}>
                                 <LimitQuantitySelect
                                     portfolioBalance={portfolio.portfolioBalance}
                                     setQty={setQty}
@@ -254,17 +266,7 @@ function OrderConfirmationPage() {
                                     setNewPortfolioBalance={setNewPortfolioBalance}
                                 />
                             </Col>
-                            <Col style={{ marginBottom: "0.625rem" }}>
-                                <LimitPriceSelect
-                                    portfolioBalance={portfolio.portfolioBalance}
-                                    setDollarAmountSelected={setDollarAmountSelected}
-                                    qty={qty}
-                                    limitPrice={limitPrice}
-                                    buyOrSell={buyOrSell}
-                                    setLimitPrice={setLimitPrice}
-                                    setNewPortfolioBalance={setNewPortfolioBalance}
-                                />
-                            </Col>
+                            
                         </Row>
                     }
                     <AreYouSure showState={showAreYouSureModal} setShowState={setShowAreYouSureModal} 

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -224,24 +224,7 @@ function OrderConfirmationPage() {
                                 />
                                 </Col>
                         </Row>
-                        <Row>
-                            <Col style={{ marginBottom: "0.625rem" }}>
-                                <BalanceComponent
-                                    portfolioName={portfolio.portfolioName}
-                                    portfolioBalance={portfolio.portfolioBalance}
-                                    newPortfolioBalance={newPortfolioBalance}
-                                    dollarAmountSelected={dollarAmountSelected}
-                                    buyOrSell={buyOrSell}
-                                    holding={holding}
-                                    stockPrice={stock.daily_change.currentprice}
-                                    orderType={orderType}
-                                    limitPrice={limitPrice}
-                                    qty={qty}
-                                />
-                            </Col>
-                        </Row>
                     </>
-                        
                     }
                     {isShownLimitOrder &&
                         <Row className="my-2" sm={1} md={1} xs={1}>
@@ -259,7 +242,7 @@ function OrderConfirmationPage() {
                                     setLimitOrderPriceError={setLimitOrderPriceError}
                                 />
                             </Col>
-                            <Col style={{ marginBottom: "0.625rem" }}>
+                            <Col>
                                 <LimitQuantitySelect
                                     portfolioBalance={portfolio.portfolioBalance}
                                     setQty={setQty}
@@ -275,7 +258,9 @@ function OrderConfirmationPage() {
                                     setLimitOrderQuantityError={setLimitOrderQuantityError}
                                 />
                             </Col>
-                            <Col style={{ marginBottom: "0.625rem" }}>
+                        </Row>
+                    }
+                    <Col className="pb-3">
                                 <BalanceComponent
                                     portfolioName={portfolio.portfolioName}
                                     portfolioBalance={portfolio.portfolioBalance}
@@ -290,8 +275,6 @@ function OrderConfirmationPage() {
                                     gameTradeFee={gameTradeFee}
                                 />
                             </Col>
-                        </Row>
-                    }
                     <AreYouSure showState={showAreYouSureModal} setShowState={setShowAreYouSureModal} 
                             buyOrSell={buyOrSell}
                             orderType={orderType}

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -35,7 +35,8 @@ function OrderConfirmationPage() {
     const [isShownMarketOrder, setIsShownMarketOrder] = useState(false)
     const [isShownLimitOrder, setIsShownLimitOrder] = useState(false)
     const [limitPrice, setLimitPrice] = useState(0)
-    const [limitOrderError, setLimitOrderError] = useState("")
+    const [limitOrderQuantityError, setLimitOrderQuantityError] = useState("")
+    const [limitOrderPriceError, setLimitOrderPriceError] = useState("")
     const [showAreYouSureModal, setShowAreYouSureModal ] = useState(false);
    
     /// Game State ///
@@ -237,7 +238,7 @@ function OrderConfirmationPage() {
                         
                     }
                     {isShownLimitOrder &&
-                        <Row className="my-2" sm={1} md={1} >
+                        <Row className="my-2" sm={1} md={1} xs={1}>
                             <Col style={{ marginBottom: "0.625rem" }}>
                                 <LimitPriceSelect
                                     portfolioBalance={portfolio.portfolioBalance}
@@ -248,6 +249,8 @@ function OrderConfirmationPage() {
                                     setLimitPrice={setLimitPrice}
                                     stockPrice={stock.daily_change.currentprice}
                                     setNewPortfolioBalance={setNewPortfolioBalance}
+                                    limitOrderPriceError={limitOrderPriceError}
+                                    setLimitOrderPriceError={setLimitOrderPriceError}
                                 />
                             </Col>
                             <Col style={{ marginBottom: "0.625rem" }}>
@@ -262,8 +265,8 @@ function OrderConfirmationPage() {
                                     gameTradeFee={gameTradeFee}
                                     setDollarAmountSelected={setDollarAmountSelected}
                                     setNewPortfolioBalance={setNewPortfolioBalance}
-                                    limitOrderError={limitOrderError}
-                                    setLimitOrderError={setLimitOrderError}
+                                    limitOrderQuantityError={limitOrderQuantityError}
+                                    setLimitOrderQuantityError={setLimitOrderQuantityError}
                                 />
                             </Col>
                             
@@ -285,10 +288,7 @@ function OrderConfirmationPage() {
                         onClick={() =>{setShowAreYouSureModal(true)}} 
                         text="Review Trade!" 
                         disabled={
-                            limitOrderError
-
-
-
+                            (limitOrderQuantityError || limitOrderPriceError)
                         }></BottomStickyButton>
                     <div className='footerStyle'></div>
                 </Container>

--- a/src/screens/orderConfirmation/orderConfirmation.js
+++ b/src/screens/orderConfirmation/orderConfirmation.js
@@ -96,7 +96,10 @@ function OrderConfirmationPage() {
             setIsShownMarketOrder(false)
             setIsShownLimitOrder(true)
         }
-
+        /// Reset the errors when you switch orders
+        setLimitOrderQuantityError("")
+        setLimitOrderPriceError("")
+        setMarketPriceError("")
     }, [orderType])
 
 

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -122,6 +122,14 @@ h1,
     color: red;
 }
 
+.greenPositive{
+    color: #32CD32;
+}
+
+.redNegative{
+    color: #FF0000;
+}
+
 
 .linkStyle {
     text-decoration:underline !important;


### PR DESCRIPTION
This PR lets you complete limit orders through the frontend. 

You set the price you want to for a unit of stock and then how many stocks you want for both buying/selling. 

![image](https://user-images.githubusercontent.com/61060096/206158949-04fd7750-9b0b-41f0-8c42-10a1cc4848ca.png)

For a limit sell I have changed the balance component to "Potential New Spending Power" instead of "Spending Power" as it is not certain that you will actually get this money. The info box for limit sell is also different for this component, goes through example using the figures on screen of how its calculated. 

![image](https://user-images.githubusercontent.com/61060096/206159264-6ab2c3f4-cfa3-437b-ac13-fd99799cb5e3.png)
![image](https://user-images.githubusercontent.com/61060096/206159467-fe2a2d82-820c-4a88-8564-148de89e5027.png)

There is also error handling in the components now which should disable the Trade button until the user fixes the error. 
![image](https://user-images.githubusercontent.com/61060096/206159765-a67a049d-194b-4d22-8940-28bd3b31a664.png)


## Warnings 
If you mess around with the slider you will get this warning, its not an error and wont break the page just a warning. The dependencies are added to each of the useEffect arrays so you shouldn't get a terminal warning in your vs code, it's just when you move the slider a lot it causes useEffect to be called in multiple places as everything is a calculation based off the slider numbers.    
![image](https://user-images.githubusercontent.com/61060096/206159915-c932caa0-a324-41ff-ac8b-ead6b25d41f0.png)

## Future Work
1. Shouldn't have to reload to see updates when you confirm order. 
2. "See More" section of the order Summary as Paul mentioned. 
3. Redirect possibly to different page on successful order? 
4. Fix sizing of some components for Desktop view. 

