### PR TITLE
Frontend UI join game screen update

### DIFF
--- a/src/components/gameComponents/gameScreenComponents/JoinAGame/JoinAGame.js
+++ b/src/components/gameComponents/gameScreenComponents/JoinAGame/JoinAGame.js
@@ -100,7 +100,7 @@ function JoinAGame(){
                         <Modal.Body>
                             <Row xl={1} md={1} sm={1} xs={1} className="textCenter">
                         <Confetti numberOfPieces={500} recycle={false}/>
-                                <h2 className="greenSuccess"><GroupAddIcon /> Succesfully joined league: "{leagueName}"!</h2>
+                                <h2 className="greenSuccess"><GroupAddIcon /> Succesfully joined league: {leagueName}!</h2>
                                 <Col className="w-100 mb-4">
                                     <CheckCircleOutlineSharpIcon className="greenSuccess" style={{ "fontSize": "10rem" }} />
                                 </Col>

--- a/src/components/gameComponents/gameScreenComponents/JoinAGame/JoinAGame.js
+++ b/src/components/gameComponents/gameScreenComponents/JoinAGame/JoinAGame.js
@@ -19,6 +19,7 @@ function JoinAGame(){
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState("");
     const [leagueName, setLeagueName] = useState("")
+    const [leagueId, setLeagueId] = useState("")
 
     const setShow = useState(false);
     const handleClose = () => setShow(false);
@@ -46,6 +47,7 @@ function JoinAGame(){
             /// Send the request 
             const res = await API.post(APIName, path, myInit)
             setLeagueName(res.newLeague.leagueName)
+            setLeagueId(res.newLeague._id)
             if (res.newLeague.active){
                 /// If the game being joined is active then update the active portfolios state in redux 
                 /// Called becuase joining a game will also create a new portfolio for that game 
@@ -107,8 +109,8 @@ function JoinAGame(){
                             </Row>
                             <Row md={2} className="textCenter">
                                 <Col>
-                                    <Link className="w-100" to={`/game`} onClick={() => window.location.reload()}>
-                                        <Button className="mb-2 w-100">My Games</Button>
+                                    <Link className="w-100" to={`/game/${leagueId}`} >
+                                        <Button className="mb-2 w-100">View League</Button>
                                     </Link>
                                 </Col>
                                 <Col>

--- a/src/components/gameComponents/gameScreenComponents/JoinAGame/JoinAGame.js
+++ b/src/components/gameComponents/gameScreenComponents/JoinAGame/JoinAGame.js
@@ -13,7 +13,8 @@ import Modal from 'react-bootstrap/Modal';
 import CheckCircleOutlineSharpIcon from '@mui/icons-material/CheckCircleOutlineSharp';
 import Confetti from 'react-confetti'
 import GroupAddIcon from '@mui/icons-material/GroupAdd';
-
+import QueryStatsIcon from '@mui/icons-material/QueryStats';
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 function JoinAGame(){
     const [accessCode, setAccessCode] = useState('')
     const [loading, setLoading] = useState(false);
@@ -110,12 +111,12 @@ function JoinAGame(){
                             <Row md={2} className="textCenter">
                                 <Col>
                                     <Link className="w-100" to={`/game/${leagueId}`} >
-                                        <Button className="mb-2 w-100">View League</Button>
+                                        <Button className="mb-2 w-100">View League <EmojiEventsIcon></EmojiEventsIcon></Button>
                                     </Link>
                                 </Col>
                                 <Col>
                                     <Link className="w-100" to={`/stockdiscovery`}>
-                                        <Button className="mb-2 w-100">Explore Stocks</Button>
+                                        <Button className="mb-2 w-100">Explore Stocks <QueryStatsIcon></QueryStatsIcon></Button>
                                     </Link>
                                 </Col>
 

--- a/src/components/gameComponents/gameScreenComponents/JoinAGame/JoinAGame.js
+++ b/src/components/gameComponents/gameScreenComponents/JoinAGame/JoinAGame.js
@@ -94,7 +94,6 @@ function JoinAGame(){
                         </Form>
                    </FormContainer>
                     {error && <MessageAlert variant="danger">{error}</MessageAlert>}
-                    {error && <MessageAlert variant="danger">{error}</MessageAlert>}                  
                 {leagueName &&
                     <Modal show={setShow} onHide={handleClose} backdrop="static">
                         <Modal.Body>

--- a/src/components/gameComponents/gameScreenComponents/JoinAGame/JoinAGame.js
+++ b/src/components/gameComponents/gameScreenComponents/JoinAGame/JoinAGame.js
@@ -9,6 +9,10 @@ import MessageAlert from "../../../widgets/MessageAlert/MessageAlert";
 import LoadingSpinner from "../../../widgets/LoadingSpinner/LoadingSpinner";
 import {useSelector,useDispatch} from 'react-redux';
 import {updateActivePortfolios} from '../../../../actions/portfolioActions';
+import Modal from 'react-bootstrap/Modal';
+import CheckCircleOutlineSharpIcon from '@mui/icons-material/CheckCircleOutlineSharp';
+import Confetti from 'react-confetti'
+import GroupAddIcon from '@mui/icons-material/GroupAdd';
 
 function JoinAGame(){
     const [accessCode, setAccessCode] = useState('')
@@ -16,6 +20,8 @@ function JoinAGame(){
     const [error, setError] = useState("");
     const [leagueName, setLeagueName] = useState("")
 
+    const setShow = useState(false);
+    const handleClose = () => setShow(false);
     /// Redux
     const dispatch = useDispatch()
     const user = useSelector((state) => state.user)
@@ -88,7 +94,34 @@ function JoinAGame(){
                         </Form>
                    </FormContainer>
                     {error && <MessageAlert variant="danger">{error}</MessageAlert>}
-                    {leagueName && <MessageAlert variant="success">Succesfully Joined <span className="bolded">{leagueName}</span>, Goodluck!</MessageAlert>}
+                    {error && <MessageAlert variant="danger">{error}</MessageAlert>}                  
+                {leagueName &&
+                    <Modal show={setShow} onHide={handleClose} backdrop="static">
+                        <Modal.Body>
+                            <Row xl={1} md={1} sm={1} xs={1} className="textCenter">
+                        <Confetti numberOfPieces={500} recycle={false}/>
+                                <h2 className="greenSuccess"><GroupAddIcon /> Succesfully joined league: "{leagueName}"!</h2>
+                                <Col className="w-100 mb-4">
+                                    <CheckCircleOutlineSharpIcon className="greenSuccess" style={{ "fontSize": "10rem" }} />
+                                </Col>
+                                <Confetti numberOfPieces={500} recycle={false} />
+                            </Row>
+                            <Row md={2} className="textCenter">
+                                <Col>
+                                    <Link className="w-100" to={`/game`} onClick={() => window.location.reload()}>
+                                        <Button className="mb-2 w-100">My Games</Button>
+                                    </Link>
+                                </Col>
+                                <Col>
+                                    <Link className="w-100" to={`/stockdiscovery`}>
+                                        <Button className="mb-2 w-100">Explore Stocks</Button>
+                                    </Link>
+                                </Col>
+
+                            </Row>
+                        </Modal.Body>
+                    </Modal>
+                }
                     {loading && <LoadingSpinner/>}
             </Card.Body>
         </Card>


### PR DESCRIPTION
# Changes
- Added a new modal popup when a user successfully joins a league.
- Gives the user a link to their game homescreen or stock discovery. I tried putting in a link to the game they just signed up to however I could not get React to take in the league ID which is needed to construct the url. In the end rather than wasting more time on it I decided to just leave it as is. @DaraghK93 can attest to this, he helped me with some troubleshooting for a while until we decided to stop putting time into it.
- Confetti might be overkill but it was there on @WarrenK-design's original modal so I left it in.
- Also note that this is not in as a React component. I had it made as one at first however I was unable to pass the league name to the component for some reason, despite the same modal working when hardcoded onto the page. 

# Screenshots
## JoinGameSuccess Modal
![image](https://user-images.githubusercontent.com/78538312/206913479-4d468804-282f-4512-9a02-1b7005963b6a.png)

## React Console
![image](https://user-images.githubusercontent.com/78538312/206913492-6a49e2d0-ee85-44a0-8e53-510352703634.png)
